### PR TITLE
Improvement/TK10 Develop Transparancy Fix on Duel Score Controller Component

### DIFF
--- a/Fiero.xcodeproj/xcuserdata/illuminaty.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Fiero.xcodeproj/xcuserdata/illuminaty.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "D47EE0A3-071A-434D-B9DD-E43A06591CB8"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/Fiero/Views/Challenges/Quick/Ongoing/OngoingDuelScreenView.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/OngoingDuelScreenView.swift
@@ -35,10 +35,11 @@ struct OngoingDuelScreenView: View {
     
     var body: some View {
         ZStack {
+            firstBackgroundColor
             VStack(spacing: 0) {
                 ZStack {
                     firstBackgroundColor
-                    VStack(spacing: spacingXS) {
+                    VStack(spacing: Tokens.Spacing.lg.value) {
                         HStack {
                             Spacer()
                             
@@ -52,28 +53,21 @@ struct OngoingDuelScreenView: View {
                             }
                         }
                         .padding(.horizontal, spacingXXXS)
-
-                        Image("Olhos")
+                        
                         DuelScoreComponent(style: .first, maxValue: 10, count: 2, playerName: "Alpaca Enfurecida")
+                            .padding(.horizontal, Tokens.Spacing.lg.value)
+                        Image("Olhos")
                     }
-                    .padding(.top, spacingNano)
                 }
-                .padding(.top, Tokens.Spacing.lg.value)
-            }
-            
-            ZStack {
-                Tokens.Colors.Highlight.two.value
-                    .ignoresSafeArea(.all, edges: .bottom)
-                
+                    
                 ZStack {
                     secondBackgroundColor
-                    VStack(spacing: spacingXS) {
+                    VStack(spacing: Tokens.Spacing.lg.value) {
+                        DuelScoreComponent(style: .second, maxValue: 10, count: 2, playerName: "Eu")
+                            .padding(.horizontal, Tokens.Spacing.lg.value)
                         Image("Olhos")
-                        DuelScoreComponent(style: .second, maxValue: 10, count: 2, playerName: "Alpaca Enfurecida")
                     }
-                    .padding(.bottom, spacingNano)
                 }
-                .padding(.bottom, Tokens.Spacing.xxxl.value)
             }
         }
         .ignoresSafeArea(.all, edges: .all)

--- a/Fiero/Views/DesignSystem/Components/ScoreControllers/Duel/DuelScoreComponent.swift
+++ b/Fiero/Views/DesignSystem/Components/ScoreControllers/Duel/DuelScoreComponent.swift
@@ -18,13 +18,12 @@ struct DuelScoreComponent: View {
          ZStack{
              RoundedRectangle(cornerRadius: style.borderRadius)
                  .foregroundColor(style.backgroundColor)
+                 .opacity(0.2)
 
-             VStack(alignment:.center ) {
+             VStack(alignment:.center, spacing: Tokens.Spacing.nano.value ) {
                  HStack() {
                      Button(action: {
-                         if count > 0{
-                             count -= 1
-                         }
+                        count -= 1
                      }) {
                          Image(systemName: style.minusIcon)
                              .resizable()
@@ -38,15 +37,12 @@ struct DuelScoreComponent: View {
 
                      Text("\(count)")
                          .foregroundColor(style.buttonColor)
-                         .font(.system(size: 34))
-                         .bold()
+                         .font(style.numberFont)
 
                      Spacer()
 
                      Button(action: {
-                         if count < maxValue{
-                             count += 1
-                         }
+                        count += 1
                      }) {
                          Image(systemName: style.plusIcon)
                              .resizable()
@@ -59,11 +55,12 @@ struct DuelScoreComponent: View {
 
                  Text("\(playerName)")
                      .foregroundColor(style.buttonColor)
-                     .font(.system(size: 24))
+                     .font(style.nameFont)
                      .padding(.horizontal, style.spacingVertical)
              }
+             .padding(.vertical, style.spacingAll)
          }
-         .frame(width: 285, height: 120)
+         .frame(height: 120)
      }
  }
 

--- a/Fiero/Views/DesignSystem/Components/ScoreControllers/Duel/DuelScoreStyle.swift
+++ b/Fiero/Views/DesignSystem/Components/ScoreControllers/Duel/DuelScoreStyle.swift
@@ -29,8 +29,8 @@
          }
      }
      //MARK: - Fonts
-     var textFont: Font {
-         return Tokens.FontStyle.largeTitle.font(weigth: .regular)
+     var nameFont: Font {
+         return Tokens.FontStyle.title2.font(weigth: .regular)
      }
      var numberFont: Font {
          return Tokens.FontStyle.largeTitle.font(weigth: .bold)
@@ -38,7 +38,7 @@
 
      //MARK: - Radius
      var borderRadius: CGFloat {
-         return Tokens.Border.BorderRadius.small.value
+         return Tokens.Border.BorderRadius.normal.value
      }
 
      //MARK: - Icons
@@ -54,5 +54,8 @@
      }
      var spacingVertical: Double{
          return Tokens.Spacing.nano.value
+     }
+     var spacingAll: Double {
+         return Tokens.Spacing.xs.value
      }
  }

--- a/Fiero/Views/DesignSystem/Tokens.swift
+++ b/Fiero/Views/DesignSystem/Tokens.swift
@@ -43,6 +43,7 @@ enum Tokens {
         enum BorderRadius {
             case none
             case small
+            case normal
             case circular
             
             var value: CGFloat {
@@ -51,6 +52,8 @@ enum Tokens {
                         return CGFloat(0.0)
                     case .small:
                         return CGFloat(8.0)
+                    case .normal:
+                        return CGFloat(20.0)
                     case .circular:
                         return CGFloat(500.0)
                 }


### PR DESCRIPTION
# What was done? ✅
> Describe in a few words what have you done? 
> - Step 1: Fixed second portion of duel screen (`ZStack`)
> - Step 2: Fixed Play/Pause Button on Duel Screen (`ZStack`)
> - Step 3: Inverted layout of `DuelScoreComponent` and `Image` on duel screen
> - Step 4: Adjusted `DuelScoreComponent` transparency
> - Step 5: Fixed increase and decrease points on DuelScoreComponent
> - Step 6: Fixed integration of Pause Screen with Duel Screen on Button Pressed

# Description 📝
## Project Info 📈
> - US **06**
> - Task 
>   - ID: **35**
>   - Title: **Develop Transparancy Fix on Duel Score Controller Component**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
<img width="400" alt="Screenshot of duel ongoing quick challenge screen on iPhone 13 pro max" src="https://user-images.githubusercontent.com/51174686/185212394-4bd52b53-47cb-4b2a-867a-7a1f642f0f22.png">
<img width="400" alt="Screenshot of duel ongoing quick challenge screen on iPhone SE (3rd generation)" src="https://user-images.githubusercontent.com/51174686/185212488-76631e63-76e8-439b-ae92-06541e7c2b43.png">

https://user-images.githubusercontent.com/51174686/185213484-17a2ab6e-1169-4bed-b248-5bd6148564a8.mp4

**Additional context** 🌎
Paddings on iPhone SE not working well
