### PR TITLE
feat: refact viewmodels + list update without pull to refresh

### DIFF
--- a/Fiero/App/FieroApp.swift
+++ b/Fiero/App/FieroApp.swift
@@ -21,6 +21,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct FieroApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
+    
     init() {
         UINavigationBar.appearance().tintColor = .white
     }

--- a/Fiero/QuickChallengeResponses.swift
+++ b/Fiero/QuickChallengeResponses.swift
@@ -16,3 +16,8 @@ struct QuickChallengePOSTResponse: Codable {
     
     var quickChallenge: [QuickChallenge]
 }
+
+struct QuickChallengeDELETEResponse: Decodable {
+    
+    var message: String?
+}

--- a/Fiero/ViewModel/QuickChallengeViewModel.swift
+++ b/Fiero/ViewModel/QuickChallengeViewModel.swift
@@ -13,7 +13,6 @@ class QuickChallengeViewModel: ObservableObject {
     //MARK: - Variables Setup
     @Published var challengesList: [QuickChallenge] = []
     @Published var serverResponse: ServerResponse
-    @Published var didUpdateChallenges: Bool = false
     
     private let BASE_URL: String = "localhost"
     //    private let BASE_URL: String = "ec2-18-229-132-19.sa-east-1.compute.amazonaws.com"
@@ -34,7 +33,6 @@ class QuickChallengeViewModel: ObservableObject {
     
     //MARK: - Create Quick Challenge
     func createQuickChallenge(name: String, challengeType: QCType, goal: Int, goalMeasure: String, online: Bool = false, numberOfTeams: Int, maxTeams: Int) {
-        self.didUpdateChallenges = false
         self.serverResponse = .unknown
         
         let challengeJson = """
@@ -65,17 +63,17 @@ class QuickChallengeViewModel: ObservableObject {
                 case .finished:
                     print("Publisher received sucessfully")
                 }
-            }, receiveValue: { [weak self] urlResponse in
-                guard let response = urlResponse.item else {
-                    self?.serverResponse.statusCode = urlResponse.statusCode
-                    print("error response status code: \(urlResponse.statusCode)")
+            }, receiveValue: { [weak self] rawURLResponse in
+                guard let response = rawURLResponse.item else {
+                    self?.serverResponse.statusCode = rawURLResponse.statusCode
+                    print("error response status code: \(rawURLResponse.statusCode)")
                     return
                 }
                 
-                self?.serverResponse.statusCode = urlResponse.statusCode
+                self?.serverResponse.statusCode = rawURLResponse.statusCode
                 self?.challengesList.append(contentsOf: response.quickChallenge)
                 print("successful response: \(response)")
-                print("response status code: \(urlResponse.statusCode)")
+                print("response status code: \(rawURLResponse.statusCode)")
 
             })
             .store(in: &cancellables)
@@ -83,7 +81,6 @@ class QuickChallengeViewModel: ObservableObject {
     
     //MARK: - Get User Challenges
     func getUserChallenges() {
-        self.didUpdateChallenges = false
         self.serverResponse = .unknown
         let userToken = keyValueStorage.string(forKey: "AuthToken")!
         
@@ -100,28 +97,27 @@ class QuickChallengeViewModel: ObservableObject {
                 case .finished:
                     print("Publisher received sucessfully")
                 }
-            }, receiveValue: { [weak self] urlResponse in
-                if let response = urlResponse.item {
-                    self?.challengesList = response.quickChallenges
-                    self?.didUpdateChallenges = true
+            }, receiveValue: { [weak self] rawURLResponse in
+                guard let response = rawURLResponse.item else {
+                    self?.serverResponse.statusCode = rawURLResponse.statusCode
+                    print("error while fetching challenges: \(String(describing: self?.serverResponse.statusCode))")
+                    return
                 }
-                
-                self?.serverResponse.statusCode = urlResponse.statusCode
-                print("error while fetching challenges: \(String(describing: self?.serverResponse.statusCode))")
+                self?.challengesList = response.quickChallenges
+                self?.serverResponse.statusCode = rawURLResponse.statusCode
             })
             .store(in: &cancellables)
     }
     
-    //MARK: - Get User Challenges
+    //MARK: - Delete User Challenges
     func deleteChallenge(by id: String) {
-        self.didUpdateChallenges = false
         self.serverResponse = .unknown
         let userToken = self.keyValueStorage.string(forKey: "AuthToken")!
         
         let request = makeDELETERequest(param: id, scheme: "http", port: 3333, baseURL: BASE_URL, endPoint: ENDPOINT_DELETE_CHALLENGES, authToken: userToken)
         
         self.client.perform(for: request)
-            .decodeHTTPResponse(type: [String:String].self, decoder: JSONDecoder())
+            .decodeHTTPResponse(type: QuickChallengeDELETEResponse.self, decoder: JSONDecoder())
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { result in
@@ -134,10 +130,11 @@ class QuickChallengeViewModel: ObservableObject {
             }, receiveValue: { [weak self] rawURLResponse in
                 guard let response = rawURLResponse.item else {
                     self?.serverResponse.statusCode = rawURLResponse.statusCode
-                    print(self?.serverResponse.statusCode)
+                    print(self?.serverResponse.statusCode as Any)
                     return
                 }
                 self?.challengesList.removeAll(where: { $0.id == id} )
+                self?.serverResponse.statusCode = rawURLResponse.statusCode
                 print(response)
             })
             .store(in: &cancellables)

--- a/Fiero/ViewModel/QuickChallengeViewModel.swift
+++ b/Fiero/ViewModel/QuickChallengeViewModel.swift
@@ -36,6 +36,7 @@ class QuickChallengeViewModel: ObservableObject {
     func createQuickChallenge(name: String, challengeType: QCType, goal: Int, goalMeasure: String, online: Bool = false, numberOfTeams: Int, maxTeams: Int) {
         self.didUpdateChallenges = false
         self.serverResponse = .unknown
+        
         let challengeJson = """
         {
             "name" : "\(name)",
@@ -74,7 +75,7 @@ class QuickChallengeViewModel: ObservableObject {
                 self?.serverResponse.statusCode = urlResponse.statusCode
                 self?.challengesList.append(contentsOf: response.quickChallenge)
                 print("successful response: \(response)")
-                print("successful response: \(urlResponse.statusCode)")
+                print("response status code: \(urlResponse.statusCode)")
 
             })
             .store(in: &cancellables)

--- a/Fiero/ViewModel/QuickChallengeViewModel.swift
+++ b/Fiero/ViewModel/QuickChallengeViewModel.swift
@@ -35,6 +35,7 @@ class QuickChallengeViewModel: ObservableObject {
     //MARK: - Create Quick Challenge
     func createQuickChallenge(name: String, challengeType: QCType, goal: Int, goalMeasure: String, online: Bool = false, numberOfTeams: Int, maxTeams: Int) {
         self.didUpdateChallenges = false
+        self.serverResponse = .unknown
         let challengeJson = """
         {
             "name" : "\(name)",
@@ -71,7 +72,7 @@ class QuickChallengeViewModel: ObservableObject {
                 }
                 
                 self?.serverResponse.statusCode = urlResponse.statusCode
-                self?.didUpdateChallenges = true
+                self?.challengesList.append(contentsOf: response.quickChallenge)
                 print("successful response: \(response)")
                 print("successful response: \(urlResponse.statusCode)")
 
@@ -82,6 +83,7 @@ class QuickChallengeViewModel: ObservableObject {
     //MARK: - Get User Challenges
     func getUserChallenges() {
         self.didUpdateChallenges = false
+        self.serverResponse = .unknown
         let userToken = keyValueStorage.string(forKey: "AuthToken")!
         
         let request = makeGETRequest(scheme: "http", port: 3333, baseURL: BASE_URL, endPoint: ENDPOINT_GET_CHALLENGES, authToken: userToken)
@@ -112,6 +114,7 @@ class QuickChallengeViewModel: ObservableObject {
     //MARK: - Get User Challenges
     func deleteChallenge(by id: String) {
         self.didUpdateChallenges = false
+        self.serverResponse = .unknown
         let userToken = self.keyValueStorage.string(forKey: "AuthToken")!
         
         let request = makeDELETERequest(param: id, scheme: "http", port: 3333, baseURL: BASE_URL, endPoint: ENDPOINT_DELETE_CHALLENGES, authToken: userToken)
@@ -133,9 +136,8 @@ class QuickChallengeViewModel: ObservableObject {
                     print(self?.serverResponse.statusCode)
                     return
                 }
-                self?.didUpdateChallenges = true
+                self?.challengesList.removeAll(where: { $0.id == id} )
                 print(response)
-                
             })
             .store(in: &cancellables)
     }

--- a/Fiero/Views/Challenges/ChallengesListScreenView.swift
+++ b/Fiero/Views/Challenges/ChallengesListScreenView.swift
@@ -9,12 +9,11 @@ import SwiftUI
 
 struct ChallengesListScreenView: View {
     @Environment(\.rootPresentationMode) var rootPresentationMode
+    @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
     
-    @StateObject var quickChallengeViewModel: QuickChallengeViewModel = QuickChallengeViewModel()
     @State var quickChallenges: [QuickChallenge] = []
     @State var isPresentingQuickChallengeCreation: Bool = false
     @State var isPresentingChallengeDetails: Bool = false
-    @State var serverResponse: ServerResponse = .unknown
     
     var body: some View {
         NavigationView {
@@ -79,16 +78,7 @@ struct ChallengesListScreenView: View {
             self.quickChallengeViewModel.getUserChallenges()
         })
         .onChange(of: self.quickChallengeViewModel.challengesList, perform: { quickChallenges in
-            self.quickChallenges = []
             self.quickChallenges = quickChallenges
-        })
-        .onChange(of: self.quickChallengeViewModel.serverResponse, perform: { serverResponse in
-            self.serverResponse = serverResponse
-            
-            if self.serverResponse.statusCode != 200 &&
-                self.serverResponse.statusCode != 201 {
-                //toggle alert
-            }
         })
         .navigationViewStyle(StackNavigationViewStyle())
         .environment(\.rootPresentationMode, self.$isPresentingQuickChallengeCreation)

--- a/Fiero/Views/Challenges/EmptyChallengesView.swift
+++ b/Fiero/Views/Challenges/EmptyChallengesView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct EmptyChallengesView: View {
+    @Environment(\.rootPresentationMode) var rootPresentationMode
+
     @State var isPresented: Bool = false
     
     var body: some View {
@@ -50,6 +52,8 @@ struct EmptyChallengesView: View {
         .navigationTitle("Desafios")
         .makeDarkModeFullScreen()
         .environment(\.colorScheme, .dark)
+        .environment(\.rootPresentationMode, self.$isPresented)
+
     }
 }
 

--- a/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
+++ b/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
@@ -9,13 +9,11 @@ import SwiftUI
 
 struct QCAmountWinRulesView: View {
     @Environment(\.presentationMode) var presentationMode
-    
-    @StateObject var quickChallengeViewModel: QuickChallengeViewModel = QuickChallengeViewModel()
+    @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
     
     @State var goal: String = ""
     @State var pushNextView: Bool = false
     @State var isPresentingAlert: Bool = false
-    @State var serverResponse: ServerResponse = .unknown
     
     var primaryColor: Color
     var secondaryColor: Color
@@ -76,7 +74,7 @@ struct QCAmountWinRulesView: View {
             .padding(.horizontal, Tokens.Spacing.xxxs.value)
             
             NavigationLink("", isActive: self.$pushNextView) {
-                QCChallengeCreatedView(quickChallengeViewModel: self.quickChallengeViewModel, serverResponse: self.$serverResponse, challengeType: self.challengeType, challengeName: self.challengeName, challengeParticipants: self.challengeParticipants, goal: Int(self.goal) ?? 999)
+                QCChallengeCreatedView(challengeType: self.challengeType, challengeName: self.challengeName, challengeParticipants: self.challengeParticipants, goal: Int(self.goal) ?? 999)
             }
         }
         .alert(isPresented: self.$isPresentingAlert, content: {
@@ -85,10 +83,7 @@ struct QCAmountWinRulesView: View {
                   dismissButton: .cancel(Text("OK"), action: { self.isPresentingAlert = false })
             )
         })
-        .onChange(of: self.quickChallengeViewModel.serverResponse, perform: { serverResponse in
-            self.serverResponse = serverResponse
-            print(self.serverResponse.statusCode)
-            
+        .onChange(of: self.quickChallengeViewModel.challengesList, perform: { _ in
             self.pushNextView.toggle()
         })
         .makeDarkModeFullScreen()

--- a/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
+++ b/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
@@ -11,11 +11,10 @@ struct QCChallengeCreatedView: View {
     //MARK: - Variables Setup
     @Environment(\.rootPresentationMode) private var rootPresentationMode
     
-    @ObservedObject var quickChallengeViewModel: QuickChallengeViewModel
+    @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
     @State var didPushToHomeScreen: Bool = false
     @State var didPushToStartChallenge: Bool = false
     @State var isPresentingAlert: Bool = false
-    @Binding var serverResponse: ServerResponse
     
     var challengeType: QCType
     var challengeName: String
@@ -33,8 +32,8 @@ struct QCChallengeCreatedView: View {
     }
     
     var title: String {
-        if serverResponse.statusCode != 201 &&
-            serverResponse.statusCode != 200 {
+        if self.quickChallengeViewModel.serverResponse.statusCode != 201 &&
+            self.quickChallengeViewModel.serverResponse.statusCode != 200 {
             return "Não conseguimos \ncriar seu desafio"
         }
         
@@ -58,8 +57,8 @@ struct QCChallengeCreatedView: View {
             Spacer()
             
             //MARK: - Bottom Buttons
-            if self.serverResponse.statusCode != 201 &&
-                self.serverResponse.statusCode != 200 {
+            if self.quickChallengeViewModel.serverResponse.statusCode != 201 &&
+                self.quickChallengeViewModel.serverResponse.statusCode != 200 {
                 ButtonComponent(style: .secondary(isEnabled: true), text: "Tentar novamente", action: {
                     self.quickChallengeViewModel.createQuickChallenge(name: self.challengeName, challengeType: self.challengeType, goal: self.goal, goalMeasure: self.goalMeasure, numberOfTeams: self.challengeParticipants, maxTeams: self.challengeParticipants)
                 })
@@ -94,15 +93,13 @@ struct QCChallengeCreatedView: View {
         }
         .alert(isPresented: self.$isPresentingAlert, content: {
             Alert(title: Text("Erro"),
-                  message: Text(self.serverResponse.description),
+                  message: Text(self.quickChallengeViewModel.serverResponse.description),
                   dismissButton: .cancel(Text("OK"), action: { self.isPresentingAlert = false })
             )
         })
-        .onChange(of: self.quickChallengeViewModel.serverResponse, perform: { serverResponse in
-            self.serverResponse = serverResponse
-            
-            if self.serverResponse.statusCode != 201 &&
-                self.serverResponse.statusCode != 200 {
+        .onChange(of: self.quickChallengeViewModel.challengesList, perform: { _ in
+            if self.quickChallengeViewModel.serverResponse.statusCode != 201 &&
+                self.quickChallengeViewModel.serverResponse.statusCode != 200 {
                 self.isPresentingAlert.toggle()
             }
         })
@@ -114,8 +111,8 @@ struct QCChallengeCreatedView: View {
 
 struct QuickChallengeCreatedView_Previews: PreviewProvider {
     static var previews: some View {
-        QCChallengeCreatedView(quickChallengeViewModel: QuickChallengeViewModel(), serverResponse: .constant(.badRequest), challengeType: .amount, challengeName: "", challengeParticipants: 0, goal: 0)
-            //.previewDevice(PreviewDevice(rawValue: "iPhone SE (3rd generation)"))
+        QCChallengeCreatedView(challengeType: .amount, challengeName: "", challengeParticipants: 0, goal: 0)
             .previewDevice(PreviewDevice(rawValue: "iPhone 8 Plus"))
+            .environmentObject(QuickChallengeViewModel())
     }
 }

--- a/Fiero/Views/ContentView.swift
+++ b/Fiero/Views/ContentView.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var pushHomeView: Bool = false
-
+    @StateObject var quickChallengeViewModel: QuickChallengeViewModel = QuickChallengeViewModel()
+    
     var body: some View {
         if self.pushHomeView {
             withAnimation {
                 ChallengesListScreenView()
                     .transition(.asymmetric(insertion: .move(edge: .leading), removal: .move(edge: .leading)))
+                    .environmentObject(self.quickChallengeViewModel)
             }
         }
 

--- a/FieroTests/Challenges/QuickChallengeViewModelTests.swift
+++ b/FieroTests/Challenges/QuickChallengeViewModelTests.swift
@@ -30,7 +30,7 @@ class QuickChallengeViewModelTests: XCTestCase {
         self.cancellables.removeAll()
     }
     
-    private func getJSON() -> String {
+    private func getJSONResponseForPOSTRequest() -> String {
         return """
         {
             "quickChallenge": [
@@ -103,13 +103,265 @@ class QuickChallengeViewModelTests: XCTestCase {
         """
     }
     
+    private func getJSONResponseForGETRequest() -> String {
+        return """
+        {
+            "quickChallenges": [
+                {
+                    "id": "7511c0ca-7330-4b8f-b0e9-9927ad897daf",
+                    "name": "Primeira",
+                    "invitationCode": "901e8892-5ec8-4d24-b16d-5285974470c3",
+                    "type": "amount",
+                    "goal": 1111,
+                    "goalMeasure": "unity",
+                    "finished": false,
+                    "ownerId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                    "online": false,
+                    "alreadyBegin": false,
+                    "maxTeams": 2,
+                    "createdAt": "2022-08-17T22:35:08.761Z",
+                    "updatedAt": "2022-08-17T22:35:08.761Z",
+                    "teams": [
+                        {
+                            "id": "119ba5ff-a7e4-4dae-91d2-af26b7fd9943",
+                            "name": "qw",
+                            "quickChallengeId": "7511c0ca-7330-4b8f-b0e9-9927ad897daf",
+                            "ownerId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                            "createdAt": "2022-08-17T22:35:08.769Z",
+                            "updatedAt": "2022-08-17T22:35:08.769Z",
+                            "members": [
+                                {
+                                    "id": "c46bdc81-8965-477d-bb95-d7fb08c5473c",
+                                    "score": 0,
+                                    "userId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                                    "teamId": "119ba5ff-a7e4-4dae-91d2-af26b7fd9943",
+                                    "beginDate": null,
+                                    "botPicture": null,
+                                    "createdAt": "2022-08-17T22:35:08.775Z",
+                                    "updatedAt": "2022-08-17T22:35:08.775Z"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "f84d6990-a835-4588-9c48-2926fa97922e",
+                            "name": "player2",
+                            "quickChallengeId": "7511c0ca-7330-4b8f-b0e9-9927ad897daf",
+                            "ownerId": null,
+                            "createdAt": "2022-08-17T22:35:08.769Z",
+                            "updatedAt": "2022-08-17T22:35:08.769Z",
+                            "members": [
+                                {
+                                    "id": "bb0cc161-1aa6-475f-9ee0-173bd89f84e6",
+                                    "score": 0,
+                                    "userId": null,
+                                    "teamId": "f84d6990-a835-4588-9c48-2926fa97922e",
+                                    "beginDate": null,
+                                    "botPicture": "player2",
+                                    "createdAt": "2022-08-17T22:35:08.775Z",
+                                    "updatedAt": "2022-08-17T22:35:08.775Z"
+                                }
+                            ]
+                        }
+                    ],
+                    "owner": {
+                        "id": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                        "email": "qw@qw.com",
+                        "name": "qw",
+                        "createdAt": "2022-08-05T23:18:19.441Z",
+                        "updatedAt": "2022-08-05T23:18:19.441Z"
+                    }
+                },
+                {
+                    "id": "842d8deb-9d9f-4b60-b43e-7efdb70ac175",
+                    "name": "BRENDA RAINHA",
+                    "invitationCode": "ff5a710d-1b85-47e4-8b3c-44e9e52fabd4",
+                    "type": "amount",
+                    "goal": 11111,
+                    "goalMeasure": "unity",
+                    "finished": false,
+                    "ownerId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                    "online": false,
+                    "alreadyBegin": false,
+                    "maxTeams": 3,
+                    "createdAt": "2022-08-18T20:57:00.313Z",
+                    "updatedAt": "2022-08-18T20:57:00.313Z",
+                    "teams": [
+                        {
+                            "id": "a69c0471-5c14-4280-80c5-305ee4de2815",
+                            "name": "qw",
+                            "quickChallengeId": "842d8deb-9d9f-4b60-b43e-7efdb70ac175",
+                            "ownerId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                            "createdAt": "2022-08-18T20:57:00.322Z",
+                            "updatedAt": "2022-08-18T20:57:00.322Z",
+                            "members": [
+                                {
+                                    "id": "defb5e16-288f-45e1-b682-c8193d705a11",
+                                    "score": 0,
+                                    "userId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                                    "teamId": "a69c0471-5c14-4280-80c5-305ee4de2815",
+                                    "beginDate": null,
+                                    "botPicture": null,
+                                    "createdAt": "2022-08-18T20:57:00.331Z",
+                                    "updatedAt": "2022-08-18T20:57:00.331Z"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "b752877e-d36f-4ae7-be67-65ecfb8a31bb",
+                            "name": "player2",
+                            "quickChallengeId": "842d8deb-9d9f-4b60-b43e-7efdb70ac175",
+                            "ownerId": null,
+                            "createdAt": "2022-08-18T20:57:00.322Z",
+                            "updatedAt": "2022-08-18T20:57:00.322Z",
+                            "members": [
+                                {
+                                    "id": "56a1efe0-4edd-41d5-94e5-3750d4bee1b5",
+                                    "score": 0,
+                                    "userId": null,
+                                    "teamId": "b752877e-d36f-4ae7-be67-65ecfb8a31bb",
+                                    "beginDate": null,
+                                    "botPicture": "player2",
+                                    "createdAt": "2022-08-18T20:57:00.331Z",
+                                    "updatedAt": "2022-08-18T20:57:00.331Z"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "879453f3-9d05-4c0a-a550-c546f5b3c180",
+                            "name": "player3",
+                            "quickChallengeId": "842d8deb-9d9f-4b60-b43e-7efdb70ac175",
+                            "ownerId": null,
+                            "createdAt": "2022-08-18T20:57:00.322Z",
+                            "updatedAt": "2022-08-18T20:57:00.322Z",
+                            "members": [
+                                {
+                                    "id": "7f1fc6c6-8d82-4981-b7ca-e89e42e83ae5",
+                                    "score": 0,
+                                    "userId": null,
+                                    "teamId": "879453f3-9d05-4c0a-a550-c546f5b3c180",
+                                    "beginDate": null,
+                                    "botPicture": "player3",
+                                    "createdAt": "2022-08-18T20:57:00.331Z",
+                                    "updatedAt": "2022-08-18T20:57:00.331Z"
+                                }
+                            ]
+                        }
+                    ],
+                    "owner": {
+                        "id": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                        "email": "qw@qw.com",
+                        "name": "qw",
+                        "createdAt": "2022-08-05T23:18:19.441Z",
+                        "updatedAt": "2022-08-05T23:18:19.441Z"
+                    }
+                },
+                {
+                    "id": "a36e24a7-bcd1-483c-8444-39668c816c79",
+                    "name": "CASA CMG ",
+                    "invitationCode": "ba4b6ae9-3e98-4366-b22e-17f01f8b9dd4",
+                    "type": "amount",
+                    "goal": 11111,
+                    "goalMeasure": "unity",
+                    "finished": false,
+                    "ownerId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                    "online": false,
+                    "alreadyBegin": false,
+                    "maxTeams": 2,
+                    "createdAt": "2022-08-18T20:57:20.303Z",
+                    "updatedAt": "2022-08-18T20:57:20.303Z",
+                    "teams": [
+                        {
+                            "id": "26a0d8e9-d887-4ea7-bd1d-242b91e2fdf2",
+                            "name": "qw",
+                            "quickChallengeId": "a36e24a7-bcd1-483c-8444-39668c816c79",
+                            "ownerId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                            "createdAt": "2022-08-18T20:57:20.311Z",
+                            "updatedAt": "2022-08-18T20:57:20.311Z",
+                            "members": [
+                                {
+                                    "id": "5a7db1a7-ae20-488d-86af-d163a1169229",
+                                    "score": 0,
+                                    "userId": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                                    "teamId": "26a0d8e9-d887-4ea7-bd1d-242b91e2fdf2",
+                                    "beginDate": null,
+                                    "botPicture": null,
+                                    "createdAt": "2022-08-18T20:57:20.318Z",
+                                    "updatedAt": "2022-08-18T20:57:20.318Z"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "66527ece-8a90-41cf-acc5-ff9896acabf5",
+                            "name": "player2",
+                            "quickChallengeId": "a36e24a7-bcd1-483c-8444-39668c816c79",
+                            "ownerId": null,
+                            "createdAt": "2022-08-18T20:57:20.311Z",
+                            "updatedAt": "2022-08-18T20:57:20.311Z",
+                            "members": [
+                                {
+                                    "id": "7436e8cf-b898-4b6a-8473-1c36c7bc4d2d",
+                                    "score": 0,
+                                    "userId": null,
+                                    "teamId": "66527ece-8a90-41cf-acc5-ff9896acabf5",
+                                    "beginDate": null,
+                                    "botPicture": "player2",
+                                    "createdAt": "2022-08-18T20:57:20.318Z",
+                                    "updatedAt": "2022-08-18T20:57:20.318Z"
+                                }
+                            ]
+                        }
+                    ],
+                    "owner": {
+                        "id": "d15cda7f-e619-4281-a07c-a848edc0213b",
+                        "email": "qw@qw.com",
+                        "name": "qw",
+                        "createdAt": "2022-08-05T23:18:19.441Z",
+                        "updatedAt": "2022-08-05T23:18:19.441Z"
+                    }
+                }
+            ]
+        }
+        """
+    }
+    
+    private func getJSONResponseForDELETERequest() -> String {
+        return """
+        {
+            "error": {
+                "query": "SELECT DISTINCT \"distinctAlias\".\"QuickChallenge_id\" as \"ids_QuickChallenge_id\" FROM (SELECT \"QuickChallenge\".\"id\" AS \"QuickChallenge_id\", \"QuickChallenge\".\"name\" AS \"QuickChallenge_name\", \"QuickChallenge\".\"invitationCode\" AS \"QuickChallenge_invitationCode\", \"QuickChallenge\".\"owner_id\" AS \"QuickChallenge_owner_id\", \"QuickChallenge\".\"type\" AS \"QuickChallenge_type\", \"QuickChallenge\".\"goal\" AS \"QuickChallenge_goal\", \"QuickChallenge\".\"goalMeasure\" AS \"QuickChallenge_goalMeasure\", \"QuickChallenge\".\"finished\" AS \"QuickChallenge_finished\", \"QuickChallenge\".\"online\" AS \"QuickChallenge_online\", \"QuickChallenge\".\"alreadyBegin\" AS \"QuickChallenge_alreadyBegin\", \"QuickChallenge\".\"maxTeams\" AS \"QuickChallenge_maxTeams\", \"QuickChallenge\".\"created_At\" AS \"QuickChallenge_created_At\", \"QuickChallenge\".\"updated_At\" AS \"QuickChallenge_updated_At\", \"QuickChallenge_owner\".\"id\" AS \"QuickChallenge_owner_id\", \"QuickChallenge_owner\".\"name\" AS \"QuickChallenge_owner_name\", \"QuickChallenge_owner\".\"email\" AS \"QuickChallenge_owner_email\", \"QuickChallenge_owner\".\"created_At\" AS \"QuickChallenge_owner_created_At\", \"QuickChallenge_owner\".\"updated_At\" AS \"QuickChallenge_owner_updated_At\", \"QuickChallenge_teams\".\"id\" AS \"QuickChallenge_teams_id\", \"QuickChallenge_teams\".\"name\" AS \"QuickChallenge_teams_name\", \"QuickChallenge_teams\".\"quickChallenge_id\" AS \"QuickChallenge_teams_quickChallenge_id\", \"QuickChallenge_teams\".\"owner_id\" AS \"QuickChallenge_teams_owner_id\", \"QuickChallenge_teams\".\"created_At\" AS \"QuickChallenge_teams_created_At\", \"QuickChallenge_teams\".\"updated_At\" AS \"QuickChallenge_teams_updated_At\", \"QuickChallenge_teams_members\".\"id\" AS \"QuickChallenge_teams_members_id\", \"QuickChallenge_teams_members\".\"user_id\" AS \"QuickChallenge_teams_members_user_id\", \"QuickChallenge_teams_members\".\"team_id\" AS \"QuickChallenge_teams_members_team_id\", \"QuickChallenge_teams_members\".\"score\" AS \"QuickChallenge_teams_members_score\", \"QuickChallenge_teams_members\".\"beginDate\" AS \"QuickChallenge_teams_members_beginDate\", \"QuickChallenge_teams_members\".\"botPicture\" AS \"QuickChallenge_teams_members_botPicture\", \"QuickChallenge_teams_members\".\"created_At\" AS \"QuickChallenge_teams_members_created_At\", \"QuickChallenge_teams_members\".\"updated_At\" AS \"QuickChallenge_teams_members_updated_At\" FROM \"quick_challenge\" \"QuickChallenge\" LEFT JOIN \"user\" \"QuickChallenge_owner\" ON \"QuickChallenge_owner\".\"id\"=\"QuickChallenge\".\"owner_id\"  LEFT JOIN \"team\" \"QuickChallenge_teams\" ON \"QuickChallenge_teams\".\"quickChallenge_id\"=\"QuickChallenge\".\"id\"  LEFT JOIN \"team_user\" \"QuickChallenge_teams_members\" ON \"QuickChallenge_teams_members\".\"team_id\"=\"QuickChallenge_teams\".\"id\" WHERE \"QuickChallenge\".\"id\" = $1) \"distinctAlias\" ORDER BY \"QuickChallenge_id\" ASC LIMIT 1",
+                "parameters": [
+                    "ad036213-c5d0-40b6-a304-6ad0dcbcd1372"
+                ],
+                "driverError": {
+                    "length": 169,
+                    "name": "error",
+                    "severity": "ERROR",
+                    "code": "22P02",
+                    "where": "unnamed portal parameter $1 = '...'",
+                    "file": "uuid.c",
+                    "line": "134",
+                    "routine": "string_to_uuid"
+                },
+                "length": 169,
+                "severity": "ERROR",
+                "code": "22P02",
+                "where": "unnamed portal parameter $1 = '...'",
+                "file": "uuid.c",
+                "line": "134",
+                "routine": "string_to_uuid"
+            }
+        }
+        """
+    }
+    
     //MARK: - Test Cases
     //MARK: Successful QC creation - Amount
     func testSuccessfulQuickChallengeAmountCreation() {
         //given
         let expectation = expectation(description: #function)
+        expectation.expectedFulfillmentCount = 2
         
-        let json = getJSON()
+        let json = getJSONResponseForPOSTRequest()
         
         self.mockClient.mock(url: "/quickChallenge/create", statusCode: 201, json: json)
         //when
@@ -119,14 +371,25 @@ class QuickChallengeViewModelTests: XCTestCase {
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { _ in
                 expectation.fulfill()
+                //XCTAssertEqual(self?.sut.serverResponse, .created)
             })
             .store(in: &cancellables)
         
+        //when
+        self.sut.$challengesList
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { _ in
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+
         self.sut.createQuickChallenge(name: "TRUCO 2", challengeType: .amount, goal: 115, goalMeasure: "unity", numberOfTeams: 2, maxTeams: 2)
         wait(for: [expectation], timeout: 5)
         
         //then
-        XCTAssertEqual(self.sut.serverResponse, .created)
+        //XCTAssertEqual(self.sut.serverResponse, .created)
+        XCTAssertEqual(self.sut.challengesList.isEmpty, false)
     }
     
     //MARK: Wrong Goal Measure QC creation - Amount
@@ -155,10 +418,90 @@ class QuickChallengeViewModelTests: XCTestCase {
             })
             .store(in: &cancellables)
         
+        //when
+        self.sut.$challengesList
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { _ in
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
         self.sut.createQuickChallenge(name: "Shape dos fellas", challengeType: .amount, goal: 115, goalMeasure: "seconds", numberOfTeams: 3, maxTeams: 3)
         wait(for: [expectation], timeout: 5)
         
         //then
         XCTAssertEqual(self.sut.serverResponse, .badRequest)
+        XCTAssertEqual(self.sut.challengesList.isEmpty, true)
+    }
+    
+    //MARK: GET challenges
+    func testSuccessfulGetChallenges() {
+        //given
+        let expectation = expectation(description: #function)
+        expectation.expectedFulfillmentCount = 2
+        
+        let json = getJSONResponseForGETRequest()
+        
+        self.mockClient.mock(url: "/quickChallenges/createdByMe", statusCode: 201, json: json)
+        
+        //when
+        self.sut.$serverResponse
+            .dropFirst()
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { _ in
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
+        self.sut.$challengesList
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { _ in
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
+        self.sut.getUserChallenges()
+        wait(for: [expectation], timeout: 5)
+        
+        //then
+        XCTAssertEqual(self.sut.serverResponse, .created)
+        XCTAssertEqual(self.sut.challengesList.isEmpty, false)
+    }
+    
+    //MARK: Delete a challenge by ID
+    func testSuccessfulDeleteChallengeByID() {
+        //given
+        let expectation = expectation(description: #function)
+        expectation.expectedFulfillmentCount = 2
+        
+        let json = getJSONResponseForDELETERequest()
+        
+        self.mockClient.mock(url: "/quickChallenge", statusCode: 201, json: json)
+        
+        //when
+        self.sut.$serverResponse
+            .dropFirst()
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { _ in
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
+        //when
+        self.sut.$challengesList
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { _ in
+                expectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
+        //then
+        XCTAssertEqual(self.sut.serverResponse, .created)
+        XCTAssertEqual(self.sut.challengesList.isEmpty, true)
     }
 }

--- a/FieroTests/Challenges/QuickChallengeViewModelTests.swift
+++ b/FieroTests/Challenges/QuickChallengeViewModelTests.swift
@@ -15,6 +15,7 @@ class QuickChallengeViewModelTests: XCTestCase {
     var sut: QuickChallengeViewModel!
     var mockClient: MockHTTPClient!
     var mockKeyValueStorage: MockKeyValueStorage!
+    var expTimeout: Double = 2
     
     var cancellables: Set<AnyCancellable> = []
     
@@ -324,11 +325,11 @@ class QuickChallengeViewModelTests: XCTestCase {
         """
     }
     
-    private func getJSONResponseForDELETERequest() -> String {
+    private func getJSONResponseForFailDELETERequest() -> String {
         return """
         {
             "error": {
-                "query": "SELECT DISTINCT \"distinctAlias\".\"QuickChallenge_id\" as \"ids_QuickChallenge_id\" FROM (SELECT \"QuickChallenge\".\"id\" AS \"QuickChallenge_id\", \"QuickChallenge\".\"name\" AS \"QuickChallenge_name\", \"QuickChallenge\".\"invitationCode\" AS \"QuickChallenge_invitationCode\", \"QuickChallenge\".\"owner_id\" AS \"QuickChallenge_owner_id\", \"QuickChallenge\".\"type\" AS \"QuickChallenge_type\", \"QuickChallenge\".\"goal\" AS \"QuickChallenge_goal\", \"QuickChallenge\".\"goalMeasure\" AS \"QuickChallenge_goalMeasure\", \"QuickChallenge\".\"finished\" AS \"QuickChallenge_finished\", \"QuickChallenge\".\"online\" AS \"QuickChallenge_online\", \"QuickChallenge\".\"alreadyBegin\" AS \"QuickChallenge_alreadyBegin\", \"QuickChallenge\".\"maxTeams\" AS \"QuickChallenge_maxTeams\", \"QuickChallenge\".\"created_At\" AS \"QuickChallenge_created_At\", \"QuickChallenge\".\"updated_At\" AS \"QuickChallenge_updated_At\", \"QuickChallenge_owner\".\"id\" AS \"QuickChallenge_owner_id\", \"QuickChallenge_owner\".\"name\" AS \"QuickChallenge_owner_name\", \"QuickChallenge_owner\".\"email\" AS \"QuickChallenge_owner_email\", \"QuickChallenge_owner\".\"created_At\" AS \"QuickChallenge_owner_created_At\", \"QuickChallenge_owner\".\"updated_At\" AS \"QuickChallenge_owner_updated_At\", \"QuickChallenge_teams\".\"id\" AS \"QuickChallenge_teams_id\", \"QuickChallenge_teams\".\"name\" AS \"QuickChallenge_teams_name\", \"QuickChallenge_teams\".\"quickChallenge_id\" AS \"QuickChallenge_teams_quickChallenge_id\", \"QuickChallenge_teams\".\"owner_id\" AS \"QuickChallenge_teams_owner_id\", \"QuickChallenge_teams\".\"created_At\" AS \"QuickChallenge_teams_created_At\", \"QuickChallenge_teams\".\"updated_At\" AS \"QuickChallenge_teams_updated_At\", \"QuickChallenge_teams_members\".\"id\" AS \"QuickChallenge_teams_members_id\", \"QuickChallenge_teams_members\".\"user_id\" AS \"QuickChallenge_teams_members_user_id\", \"QuickChallenge_teams_members\".\"team_id\" AS \"QuickChallenge_teams_members_team_id\", \"QuickChallenge_teams_members\".\"score\" AS \"QuickChallenge_teams_members_score\", \"QuickChallenge_teams_members\".\"beginDate\" AS \"QuickChallenge_teams_members_beginDate\", \"QuickChallenge_teams_members\".\"botPicture\" AS \"QuickChallenge_teams_members_botPicture\", \"QuickChallenge_teams_members\".\"created_At\" AS \"QuickChallenge_teams_members_created_At\", \"QuickChallenge_teams_members\".\"updated_At\" AS \"QuickChallenge_teams_members_updated_At\" FROM \"quick_challenge\" \"QuickChallenge\" LEFT JOIN \"user\" \"QuickChallenge_owner\" ON \"QuickChallenge_owner\".\"id\"=\"QuickChallenge\".\"owner_id\"  LEFT JOIN \"team\" \"QuickChallenge_teams\" ON \"QuickChallenge_teams\".\"quickChallenge_id\"=\"QuickChallenge\".\"id\"  LEFT JOIN \"team_user\" \"QuickChallenge_teams_members\" ON \"QuickChallenge_teams_members\".\"team_id\"=\"QuickChallenge_teams\".\"id\" WHERE \"QuickChallenge\".\"id\" = $1) \"distinctAlias\" ORDER BY \"QuickChallenge_id\" ASC LIMIT 1",
+                "query": "SELECT DISTINCT \\"distinctAlias\\".\\"QuickChallenge_id\\" as \\"ids_QuickChallenge_id\\" FROM (SELECT \\"QuickChallenge\\".\\"id\\" AS \\"QuickChallenge_id\\", \\"QuickChallenge\\".\\"name\\" AS \\"QuickChallenge_name\\", \\"QuickChallenge\\".\\"invitationCode\\" AS \\"QuickChallenge_invitationCode\\", \\"QuickChallenge\\".\\"owner_id\\" AS \\"QuickChallenge_owner_id\\", \\"QuickChallenge\\".\\"type\\" AS \\"QuickChallenge_type\\", \\"QuickChallenge\\".\\"goal\\" AS \\"QuickChallenge_goal\\", \\"QuickChallenge\\".\\"goalMeasure\\" AS \\"QuickChallenge_goalMeasure\\", \\"QuickChallenge\\".\\"finished\\" AS \\"QuickChallenge_finished\\", \\"QuickChallenge\\".\\"online\\" AS \\"QuickChallenge_online\\", \\"QuickChallenge\\".\\"alreadyBegin\\" AS \\"QuickChallenge_alreadyBegin\\", \\"QuickChallenge\\".\\"maxTeams\\" AS \\"QuickChallenge_maxTeams\\", \\"QuickChallenge\\".\\"created_At\\" AS \\"QuickChallenge_created_At\\", \\"QuickChallenge\\".\\"updated_At\\" AS \\"QuickChallenge_updated_At\\", \\"QuickChallenge_owner\\".\\"id\\" AS \\"QuickChallenge_owner_id\\", \\"QuickChallenge_owner\\".\\"name\\" AS \\"QuickChallenge_owner_name\\", \\"QuickChallenge_owner\\".\\"email\\" AS \\"QuickChallenge_owner_email\\", \\"QuickChallenge_owner\\".\\"created_At\\" AS \\"QuickChallenge_owner_created_At\\", \\"QuickChallenge_owner\\".\\"updated_At\\" AS \\"QuickChallenge_owner_updated_At\\", \\"QuickChallenge_teams\\".\\"id\\" AS \\"QuickChallenge_teams_id\\", \\"QuickChallenge_teams\\".\\"name\\" AS \\"QuickChallenge_teams_name\\", \\"QuickChallenge_teams\\".\\"quickChallenge_id\\" AS \\"QuickChallenge_teams_quickChallenge_id\\", \\"QuickChallenge_teams\\".\\"owner_id\\" AS \\"QuickChallenge_teams_owner_id\\", \\"QuickChallenge_teams\\".\\"created_At\\" AS \\"QuickChallenge_teams_created_At\\", \\"QuickChallenge_teams\\".\\"updated_At\\" AS \\"QuickChallenge_teams_updated_At\\", \\"QuickChallenge_teams_members\\".\\"id\\" AS \\"QuickChallenge_teams_members_id\\", \\"QuickChallenge_teams_members\\".\\"user_id\\" AS \\"QuickChallenge_teams_members_user_id\\", \\"QuickChallenge_teams_members\\".\\"team_id\\" AS \\"QuickChallenge_teams_members_team_id\\", \\"QuickChallenge_teams_members\\".\\"score\\" AS \\"QuickChallenge_teams_members_score\\", \\"QuickChallenge_teams_members\\".\\"beginDate\\" AS \\"QuickChallenge_teams_members_beginDate\\", \\"QuickChallenge_teams_members\\".\\"botPicture\\" AS \\"QuickChallenge_teams_members_botPicture\\", \\"QuickChallenge_teams_members\\".\\"created_At\\" AS \\"QuickChallenge_teams_members_created_At\\", \\"QuickChallenge_teams_members\\".\\"updated_At\\" AS \\"QuickChallenge_teams_members_updated_At\\" FROM \\"quick_challenge\\" \\"QuickChallenge\\" LEFT JOIN \\"user\\" \\"QuickChallenge_owner\\" ON \\"QuickChallenge_owner\\".\\"id\\"=\\"QuickChallenge\\".\\"owner_id\\"  LEFT JOIN \\"team\\" \\"QuickChallenge_teams\\" ON \\"QuickChallenge_teams\\".\\"quickChallenge_id\\"=\\"QuickChallenge\\".\\"id\\"  LEFT JOIN \\"team_user\\" \\"QuickChallenge_teams_members\\" ON \\"QuickChallenge_teams_members\\".\\"team_id\\"=\\"QuickChallenge_teams\\".\\"id\\" WHERE \\"QuickChallenge\\".\\"id\\" = $1) \\"distinctAlias\\" ORDER BY \\"QuickChallenge_id\\" ASC LIMIT 1",
                 "parameters": [
                     "ad036213-c5d0-40b6-a304-6ad0dcbcd1372"
                 ],
@@ -354,49 +355,59 @@ class QuickChallengeViewModelTests: XCTestCase {
         """
     }
     
+    private func getJSONResponseForSuccessfulDELETERequest() -> String {
+        return """
+        {
+            "message": "successfully deleted."
+        }
+        """
+    }
+    
     //MARK: - Test Cases
     //MARK: Successful QC creation - Amount
     func testSuccessfulQuickChallengeAmountCreation() {
         //given
-        let expectation = expectation(description: #function)
-        expectation.expectedFulfillmentCount = 2
+        let serverResponseExpectation = expectation(description: #function + " serverResponseExpectation")
+        let challengesListExpectation = expectation(description: #function + " challengesListExpectation")
         
         let json = getJSONResponseForPOSTRequest()
         
         self.mockClient.mock(url: "/quickChallenge/create", statusCode: 201, json: json)
         //when
         self.sut.$serverResponse
-            .dropFirst()
+            .dropFirst(2)
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
-                //XCTAssertEqual(self?.sut.serverResponse, .created)
+                serverResponseExpectation.fulfill()
             })
             .store(in: &cancellables)
         
         //when
         self.sut.$challengesList
+            .dropFirst()
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
+                challengesListExpectation.fulfill()
             })
             .store(in: &cancellables)
 
         self.sut.createQuickChallenge(name: "TRUCO 2", challengeType: .amount, goal: 115, goalMeasure: "unity", numberOfTeams: 2, maxTeams: 2)
-        wait(for: [expectation], timeout: 5)
+        wait(for: [serverResponseExpectation, challengesListExpectation], timeout: self.expTimeout)
         
         //then
-        //XCTAssertEqual(self.sut.serverResponse, .created)
+        XCTAssertEqual(self.sut.serverResponse, .created)
         XCTAssertEqual(self.sut.challengesList.isEmpty, false)
     }
     
     //MARK: Wrong Goal Measure QC creation - Amount
     func testWrongGoalMeasureForQCByAmountCreation() {
         //given
-        let expectation = expectation(description: #function)
-        
+        let serverResponseExpectation = expectation(description: #function + " serverResponseExpectation")
+        let challengesListExpectation = expectation(description: #function + " challengesListExpectation")
+        challengesListExpectation.isInverted = true
+
         let json = """
         {
             "message": "invalid goalMeasure for Amount type",
@@ -410,25 +421,26 @@ class QuickChallengeViewModelTests: XCTestCase {
         
         //when
         self.sut.$serverResponse
-            .dropFirst()
+            .dropFirst(2)
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
+                serverResponseExpectation.fulfill()
             })
             .store(in: &cancellables)
         
         //when
         self.sut.$challengesList
+            .dropFirst()
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
+                challengesListExpectation.fulfill()
             })
             .store(in: &cancellables)
         
         self.sut.createQuickChallenge(name: "Shape dos fellas", challengeType: .amount, goal: 115, goalMeasure: "seconds", numberOfTeams: 3, maxTeams: 3)
-        wait(for: [expectation], timeout: 5)
+        wait(for: [serverResponseExpectation, challengesListExpectation], timeout: self.expTimeout)
         
         //then
         XCTAssertEqual(self.sut.serverResponse, .badRequest)
@@ -438,70 +450,122 @@ class QuickChallengeViewModelTests: XCTestCase {
     //MARK: GET challenges
     func testSuccessfulGetChallenges() {
         //given
-        let expectation = expectation(description: #function)
-        expectation.expectedFulfillmentCount = 2
+        let serverResponseExpectation = expectation(description: #function + " serverResponseExpectation")
+        let challengesListExpectation = expectation(description: #function + " challengesListExpectation")
         
         let json = getJSONResponseForGETRequest()
         
-        self.mockClient.mock(url: "/quickChallenges/createdByMe", statusCode: 201, json: json)
+        self.mockClient.mock(url: "/quickChallenge/createdByMe", statusCode: 201, json: json)
         
         //when
         self.sut.$serverResponse
-            .dropFirst()
+            .print("server response")
+            .dropFirst(2)
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
+                serverResponseExpectation.fulfill()
             })
             .store(in: &cancellables)
         
         self.sut.$challengesList
+            .print("challenge List")
+            .dropFirst()
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
+                challengesListExpectation.fulfill()
             })
             .store(in: &cancellables)
         
         self.sut.getUserChallenges()
-        wait(for: [expectation], timeout: 5)
+        wait(for: [serverResponseExpectation, challengesListExpectation], timeout: self.expTimeout)
         
         //then
         XCTAssertEqual(self.sut.serverResponse, .created)
         XCTAssertEqual(self.sut.challengesList.isEmpty, false)
     }
     
-    //MARK: Delete a challenge by ID
+    //MARK: Successful Delete a challenge by ID
     func testSuccessfulDeleteChallengeByID() {
         //given
-        let expectation = expectation(description: #function)
-        expectation.expectedFulfillmentCount = 2
+        let serverResponseExpectation = expectation(description: #function + " serverResponseExpectation")
+        let challengesListExpectation = expectation(description: #function + " challengesListExpectation")
         
-        let json = getJSONResponseForDELETERequest()
+        let json = getJSONResponseForSuccessfulDELETERequest()
         
         self.mockClient.mock(url: "/quickChallenge", statusCode: 201, json: json)
         
+        self.sut.challengesList.append(QuickChallenge(id: "842d8deb-9d9f-4b60-b43e-7efdb70ac175", name: "flemis", invitationCode: "", type: "", goal: 115, goalMeasure: "unity", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 2, createdAt: "", updatedAt: "", teams: [], owner: User(email: "tester@tester.com", name: "tester")))
+        
         //when
         self.sut.$serverResponse
-            .dropFirst()
+            .dropFirst(2)
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
+                serverResponseExpectation.fulfill()
             })
             .store(in: &cancellables)
         
         //when
         self.sut.$challengesList
+            .dropFirst()
             .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .sink(receiveValue: { _ in
-                expectation.fulfill()
+                challengesListExpectation.fulfill()
             })
             .store(in: &cancellables)
+        
+        self.sut.deleteChallenge(by: "842d8deb-9d9f-4b60-b43e-7efdb70ac175")
+        wait(for: [challengesListExpectation, serverResponseExpectation], timeout: self.expTimeout)
         
         //then
         XCTAssertEqual(self.sut.serverResponse, .created)
         XCTAssertEqual(self.sut.challengesList.isEmpty, true)
+    }
+    
+    //MARK: Unsuccessful Delete a challenge by ID
+    func testDeleteChallengeByNonExistantID() {
+        //given
+        let serverResponseExpectation = expectation(description: #function + " serverResponseExpectation")
+        let challengesListExpectation = expectation(description: #function + " challengesListExpectation")
+        challengesListExpectation.isInverted = true
+        
+        let json = getJSONResponseForFailDELETERequest()
+        
+        self.mockClient.mock(url: "/quickChallenge", statusCode: 500, json: json)
+        
+        self.sut.challengesList.append(QuickChallenge(id: "842d8deb-9d9f-4b60-b43e-7efdb70ac175", name: "flemis", invitationCode: "", type: "", goal: 115, goalMeasure: "unity", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 2, createdAt: "", updatedAt: "", teams: [], owner: User(email: "tester@tester.com", name: "tester")))
+        
+        //when
+        self.sut.$serverResponse
+            .print("server response")
+            .dropFirst(2)
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
+            .sink(receiveValue: { _ in
+                serverResponseExpectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
+        //when
+        self.sut.$challengesList
+            .print("challenge list")
+            .dropFirst()
+            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
+            .sink(receiveValue: { _ in
+                challengesListExpectation.fulfill()
+            })
+            .store(in: &cancellables)
+        
+        self.sut.deleteChallenge(by: "someWrongID")
+        wait(for: [challengesListExpectation, serverResponseExpectation], timeout: self.expTimeout)
+        
+        //then
+        XCTAssertEqual(self.sut.serverResponse, .internalError)
+        XCTAssertEqual(self.sut.challengesList.isEmpty, false)
     }
 }


### PR DESCRIPTION
# What was done? ✅
> - Step 1: Refactored QuickChallengeViewModel objects
> - Step 2: small adjustments on QuickChallengeViewModel tests

# Description 📝
## Project Info 📈
> - US **05**
> - Task 
>   - ID: **2**
>   - Title: **Develop Update Challenges List without Pull to Refresh**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
If applicable, add screenshots from Figma to help detail how this feature should be implemented.

**Additional context** 🌎
### Warning ⚠️
Test pipeline will be deactivated temporarily due to random reasons from failling tests