### PR TITLE
Feature/TK 27 Develop Front-end Integration for Ongoing Screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-
-# Created by https://www.toptal.com/developers/gitignore/api/macos,xcode,swift,swiftpackagemanager,cocoapods
-# Edit at https://www.toptal.com/developers/gitignore?templates=macos,xcode,swift,swiftpackagemanager,cocoapods
+# Created by https://www.toptal.com/developers/gitignore/api/macos,xcode,swift,cocoapods
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,xcode,swift,cocoapods
 
 ### CocoaPods ###
 ## CocoaPods GitIgnore Template
@@ -50,7 +49,6 @@ Temporary Items
 
 ## User settings
 xcuserdata/
-*.xcodeproj/xcuserdata/
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
@@ -128,23 +126,16 @@ fastlane/test_output
 
 iOSInjectionProject/
 
-### SwiftPackageManager ###
-Packages
-xcuserdata
-# *.xcodeproj
-
-
 ### Xcode ###
 
 ## Xcode 8 and earlier
 
 ### Xcode Patch ###
-!*.xcodeproj
-!*.xcodeproj/*
+*.xcodeproj/*
 !*.xcodeproj/project.pbxproj
 !*.xcodeproj/xcshareddata/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
 
-# End of https://www.toptal.com/developers/gitignore/api/macos,xcode,swift,swiftpackagemanager,cocoapods
+# End of https://www.toptal.com/developers/gitignore/api/macos,xcode,swift,cocoapods

--- a/Fiero.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Fiero.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/Fiero.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Fiero.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/Fiero.xcodeproj/xcuserdata/illuminaty.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Fiero.xcodeproj/xcuserdata/illuminaty.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Bucket
-   uuid = "D47EE0A3-071A-434D-B9DD-E43A06591CB8"
-   type = "1"
-   version = "2.0">
-</Bucket>

--- a/Fiero.xcodeproj/xcuserdata/marcelodiefenbach.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Fiero.xcodeproj/xcuserdata/marcelodiefenbach.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Bucket
-   uuid = "605D32B1-6DC0-49DE-9610-2D8107A17EC1"
-   type = "1"
-   version = "2.0">
-</Bucket>

--- a/Fiero/Extensions/View+Extensions.swift
+++ b/Fiero/Extensions/View+Extensions.swift
@@ -56,3 +56,34 @@ extension RootPresentationMode {
         self.toggle()
     }
 }
+
+struct RootViewController {
+    static func popToRootViewController() {
+        let rootController = UIApplication.shared.windows.filter { $0.isKeyWindow }.first?.rootViewController
+        rootController?.dismiss(animated: true)
+        findNavigationController(viewController: rootController)?.popToRootViewController(animated: true)
+    }
+    
+    static func dismissSheetFlow() {
+        let rootController = UIApplication.shared.windows.filter { $0.isKeyWindow }.first?.rootViewController
+        rootController?.dismiss(animated: true)
+    }
+    
+    static func findNavigationController(viewController: UIViewController?) -> UINavigationController? {
+        if viewController is UINavigationController {
+            return viewController as? UINavigationController
+        }
+        
+        if let tabBarController = viewController as? UITabBarController {
+            return findNavigationController(viewController: tabBarController.selectedViewController)
+        }
+        
+        for childController in viewController?.children ?? [] {
+            if let navController = findNavigationController(viewController: childController) {
+                return navController
+            }
+        }
+        
+        return nil
+    }
+}

--- a/Fiero/ViewModel/QuickChallengeViewModel.swift
+++ b/Fiero/ViewModel/QuickChallengeViewModel.swift
@@ -73,7 +73,7 @@ class QuickChallengeViewModel: ObservableObject {
                     return
                 }
                 
-                self?.serverResponse.statusCode = urlResponse.statusCode
+                self?.serverResponse.statusCode = rawURLResponse.statusCode
                 self?.newlyCreatedChallenge = response.quickChallenge[0]
                 self?.serverResponse.statusCode = rawURLResponse.statusCode
                 self?.challengesList.append(contentsOf: response.quickChallenge)

--- a/Fiero/ViewModel/QuickChallengeViewModel.swift
+++ b/Fiero/ViewModel/QuickChallengeViewModel.swift
@@ -14,6 +14,7 @@ class QuickChallengeViewModel: ObservableObject {
     @Published var challengesList: [QuickChallenge] = []
     @Published var serverResponse: ServerResponse
     @Published var didUpdateChallenges: Bool = false
+    @Published var newlyCreatedChallenge: QuickChallenge
     
     private let BASE_URL: String = "localhost"
     //    private let BASE_URL: String = "ec2-18-229-132-19.sa-east-1.compute.amazonaws.com"
@@ -30,6 +31,7 @@ class QuickChallengeViewModel: ObservableObject {
         self.client = client
         self.serverResponse = .unknown
         self.keyValueStorage = keyValueStorage
+        self.newlyCreatedChallenge = QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [], owner: User(email: "", name: ""))
     }
     
     //MARK: - Create Quick Challenge
@@ -71,7 +73,7 @@ class QuickChallengeViewModel: ObservableObject {
                 }
                 
                 self?.serverResponse.statusCode = urlResponse.statusCode
-                self?.didUpdateChallenges = true
+                self?.newlyCreatedChallenge = response.quickChallenge[0]
                 print("successful response: \(response)")
                 print("successful response: \(urlResponse.statusCode)")
 

--- a/Fiero/Views/Challenges/ChallengesListScreenView.swift
+++ b/Fiero/Views/Challenges/ChallengesListScreenView.swift
@@ -7,52 +7,26 @@
 
 import SwiftUI
 
-struct ChallengesListScreenView: View {
-    @Environment(\.rootPresentationMode) var rootPresentationMode
+struct HomeView: View {
     @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
     
-    @State var quickChallenges: [QuickChallenge] = []
     @State var isPresentingQuickChallengeCreation: Bool = false
     @State var isPresentingChallengeDetails: Bool = false
+    @State var isPresented: Bool = false
     @State var presentModalIndex: QuickChallenge? = nil
+
+    var quickChallenges: [QuickChallenge] {
+        self.quickChallengeViewModel.challengesList
+    }
     
     var body: some View {
         NavigationView {
             ZStack {
                 Tokens.Colors.Background.dark.value.edgesIgnoringSafeArea(.all)
+                
                 VStack {
                     if self.quickChallenges.count > 0 {
-                        if #available(iOS 15.0, *) {
-                            ListWithoutSeparator(0..<self.quickChallenges.count, id: \.self) { index in
-                                ZStack {
-                                    CustomTitleImageListRow(title: quickChallenges[index].name)
-                                }
-                                .listRowBackground(Color.clear)
-                                .onTapGesture {
-                                    self.presentModalIndex = quickChallenges[index]
-                                }
-                            }
-                            .fullScreenCover(item: $presentModalIndex) { item in
-                                ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: item)
-                            }
-                            .navigationBarHidden(false)
-                            .navigationTitle("Seus desafios")
-                            .refreshable {
-                                self.quickChallengeViewModel.getUserChallenges()
-                            }
-                            .ignoresSafeArea(.all, edges: .bottom)
-                            .listStyle(.plain)
-                        } else {
-                            //TODO: Refreshable list for iOS 14
-                            ListWithoutSeparator(0..<self.quickChallenges.count, id: \.self) { index in
-                                NavigationLink(destination: ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: self.quickChallenges[index]), label: {
-                                    CustomTitleImageListRow(title: quickChallenges[index].name)
-                                })
-                                .buttonStyle(PlainButtonStyle())
-                            }
-                            .ignoresSafeArea(.all, edges: .bottom)
-                            .listStyle(.plain)
-                        }
+                        ChallengesListScreenView(quickChallenges: self.quickChallenges)
                     }
                     else {
                         EmptyChallengesView()
@@ -61,6 +35,7 @@ struct ChallengesListScreenView: View {
                 .fullScreenCover(isPresented: $isPresentingQuickChallengeCreation) {
                     QCCategorySelectionView()
                 }
+                
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button(action: {
@@ -77,18 +52,61 @@ struct ChallengesListScreenView: View {
                     UITableView.appearance().refreshControl = UIRefreshControl()
                     self.quickChallengeViewModel.getUserChallenges()
                 })
-                .onChange(of: self.quickChallengeViewModel.challengesList, perform: { quickChallenges in
-                    self.quickChallenges = []
-                    self.quickChallenges = quickChallenges
-                })
-                .environment(\.rootPresentationMode, self.$isPresentingQuickChallengeCreation)
             }
-        }.environment(\.colorScheme, .dark)
+            
+            .navigationBarHidden(false)
+            .navigationTitle("Seus desafios")
+        }
+        .environment(\.colorScheme, .dark)
+
+    }
+}
+
+struct ChallengesListScreenView: View {
+    @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
+    
+    @State var presentModalIndex: QuickChallenge? = nil
+    
+    var quickChallenges: [QuickChallenge]
+    
+    var body: some View {
+        VStack {
+            if #available(iOS 15.0, *) {
+                ListWithoutSeparator(0..<self.quickChallenges.count, id: \.self) { index in
+                    ZStack {
+                        CustomTitleImageListRow(title: quickChallenges[index].name)
+                    }
+                    .listRowBackground(Color.clear)
+                    .onTapGesture {
+                        self.presentModalIndex = quickChallenges[index]
+                    }
+                }
+                .fullScreenCover(item: $presentModalIndex) { item in
+                    ChallengeDetailsView(quickChallenge: item)
+                        .environmentObject(self.quickChallengeViewModel)
+                }
+                .refreshable {
+                    self.quickChallengeViewModel.getUserChallenges()
+                }
+                .ignoresSafeArea(.all, edges: .bottom)
+                .listStyle(.plain)
+            } else {
+                //TODO: Refreshable list for iOS 14
+                ListWithoutSeparator(0..<self.quickChallenges.count, id: \.self) { index in
+                    NavigationLink(destination: ChallengeDetailsView(quickChallenge: self.quickChallenges[index]), label: {
+                        CustomTitleImageListRow(title: quickChallenges[index].name)
+                    })
+                    .buttonStyle(PlainButtonStyle())
+                }
+                .ignoresSafeArea(.all, edges: .bottom)
+                .listStyle(.plain)
+            }
+        }
     }
 }
 
 struct ChallengesListScreenView_Previews: PreviewProvider {
     static var previews: some View {
-        ChallengesListScreenView()
+        ChallengesListScreenView(quickChallenges: [])
     }
 }

--- a/Fiero/Views/Challenges/ChallengesListScreenView.swift
+++ b/Fiero/Views/Challenges/ChallengesListScreenView.swift
@@ -23,7 +23,7 @@ struct ChallengesListScreenView: View {
                     if #available(iOS 15.0, *) {
                         ListWithoutSeparator(0..<self.quickChallenges.count, id: \.self) { index in
                             ZStack {
-                                NavigationLink(destination: ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: self.quickChallenges[index]), label: {
+                                NavigationLink(destination: ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: self.$quickChallenges[index]), label: {
                                     EmptyView()
                                 })
                                 .opacity(0.0)
@@ -41,7 +41,7 @@ struct ChallengesListScreenView: View {
                     } else {
                         //TODO: Refreshable list for iOS 14
                         ListWithoutSeparator(0..<self.quickChallenges.count, id: \.self) { index in
-                            NavigationLink(destination: ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: self.quickChallenges[index]), label: {
+                            NavigationLink(destination: ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: self.$quickChallenges[index]), label: {
                                 CustomTitleImageListRow(title: quickChallenges[index].name)
                             })
                             .buttonStyle(PlainButtonStyle())

--- a/Fiero/Views/Challenges/EmptyChallengesView.swift
+++ b/Fiero/Views/Challenges/EmptyChallengesView.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct EmptyChallengesView: View {
-    @Environment(\.rootPresentationMode) var rootPresentationMode
-
     @State var isPresented: Bool = false
     
     var body: some View {
         VStack {
             Spacer()
+            
             Image("EmptyState")
+            
             Text("Você não é ruim \nnem bom, você \nsó não tem oponentes ainda")
                 .multilineTextAlignment(.center)
                 .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
@@ -25,20 +25,23 @@ struct EmptyChallengesView: View {
             ButtonComponent(style: .primary(isEnabled: true), text: "Criar um desafio!", action: {
                 self.isPresented.toggle()
             })
+            
             .padding()
+            
             Spacer()
-                .toolbar(content: {
-                    ToolbarItem(placement: .navigationBarTrailing, content: {
-                        Button(action: {
-                            self.isPresented.toggle()
-                        }, label: {
-                            Image(systemName: "plus")
-                                .font(Tokens.FontStyle.body.font(weigth: .bold, design: .rounded))
-                                .foregroundColor(.white)
-                        })
-                        .buttonStyle(.plain)
+            
+            .toolbar(content: {
+                ToolbarItem(placement: .navigationBarTrailing, content: {
+                    Button(action: {
+                        self.isPresented.toggle()
+                    }, label: {
+                        Image(systemName: "plus")
+                            .font(Tokens.FontStyle.body.font(weigth: .bold, design: .rounded))
+                            .foregroundColor(.white)
                     })
+                    .buttonStyle(.plain)
                 })
+            })
         }
         .navigationTitle("Desafios")
         .environment(\.colorScheme, .dark)

--- a/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
+++ b/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
@@ -16,6 +16,7 @@ struct QCAmountWinRulesView: View {
     @State var pushNextView: Bool = false
     @State var isPresentingAlert: Bool = false
     @State var serverResponse: ServerResponse = .unknown
+    @State var quickChallenge: QuickChallenge = QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [], owner: User(email: "", name: ""))
     
     var primaryColor: Color
     var secondaryColor: Color
@@ -76,7 +77,7 @@ struct QCAmountWinRulesView: View {
             .padding(.horizontal, Tokens.Spacing.xxxs.value)
             
             NavigationLink("", isActive: self.$pushNextView) {
-                QCChallengeCreatedView(quickChallengeViewModel: self.quickChallengeViewModel, serverResponse: self.$serverResponse, challengeType: self.challengeType, challengeName: self.challengeName, challengeParticipants: self.challengeParticipants, goal: Int(self.goal) ?? 999)
+                QCChallengeCreatedView(quickChallengeViewModel: self.quickChallengeViewModel, serverResponse: Binding.constant(self.quickChallengeViewModel.serverResponse), quickChallenge: self.$quickChallenge, challengeType: self.challengeType, challengeName: self.challengeName, challengeParticipants: self.challengeParticipants, goal: Int(self.goal) ?? 999)
             }
         }
         .alert(isPresented: self.$isPresentingAlert, content: {
@@ -85,9 +86,8 @@ struct QCAmountWinRulesView: View {
                   dismissButton: .cancel(Text("OK"), action: { self.isPresentingAlert = false })
             )
         })
-        .onChange(of: self.quickChallengeViewModel.serverResponse, perform: { serverResponse in
-            self.serverResponse = serverResponse
-            print(self.serverResponse.statusCode)
+        .onChange(of: self.quickChallengeViewModel.newlyCreatedChallenge, perform: { quickChallenge in
+            self.quickChallenge = quickChallenge
             
             self.pushNextView.toggle()
         })

--- a/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
+++ b/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
@@ -76,7 +76,7 @@ struct QCAmountWinRulesView: View {
             .padding(.horizontal, Tokens.Spacing.xxxs.value)
             
             NavigationLink("", isActive: self.$pushNextView) {
-                QCChallengeCreatedView(quickChallengeViewModel: self.quickChallengeViewModel, serverResponse: Binding.constant(self.quickChallengeViewModel.serverResponse), quickChallenge: self.$quickChallenge, challengeType: self.challengeType, challengeName: self.challengeName, challengeParticipants: self.challengeParticipants, goal: Int(self.goal) ?? 999)
+                QCChallengeCreatedView(serverResponse: Binding.constant(self.quickChallengeViewModel.serverResponse), quickChallenge: self.$quickChallenge, challengeType: self.challengeType, challengeName: self.challengeName, challengeParticipants: self.challengeParticipants, goal: Int(self.goal) ?? 999)
             }
         }
         .alert(isPresented: self.$isPresentingAlert, content: {

--- a/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
+++ b/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
@@ -12,7 +12,7 @@ struct ChallengeDetailsView: View {
     @ObservedObject var quickChallengeViewModel: QuickChallengeViewModel
     @State var presentDuelOngoingChallenge: Bool = false
     @State var present3or4OngoingChallenge: Bool = false
-    @State var quickChallenge: QuickChallenge
+    @Binding var quickChallenge: QuickChallenge
 
     //MARK: - Body
     var body: some View {
@@ -65,7 +65,7 @@ struct ChallengeDetailsView: View {
                     .hidden()
                     
                     NavigationLink("", isActive: self.$present3or4OngoingChallenge) {
-                        Ongoing3_4ScreenView(quickChallenge: self.quickChallenge)
+                        Ongoing3Or4WithPauseScreenView(quickChallenge: quickChallenge, didTapPauseButton: false)
                     }
                     .hidden()
                     
@@ -119,6 +119,6 @@ struct ChallengeDetailsView: View {
 //MARK: - Previews
 struct ChallengeDetailsScreenView_Previews: PreviewProvider {
     static var previews: some View {
-        ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [Team(id: "id", name: "Naty", quickChallengeId: "id", createdAt: "", updatedAt: ""), Team(id: "id2", name: "player2", quickChallengeId: "id", createdAt: "", updatedAt: "")], owner: User(email: "a@naty.pq", name: "naty")))
+        ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: .constant(QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [Team(id: "id", name: "Naty", quickChallengeId: "id", createdAt: "", updatedAt: ""), Team(id: "id2", name: "player2", quickChallengeId: "id", createdAt: "", updatedAt: "")], owner: User(email: "a@naty.pq", name: "naty"))))
     }
 }

--- a/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
+++ b/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
@@ -10,115 +10,125 @@ import SwiftUI
 struct ChallengeDetailsView: View {
     //MARK: - Variables Setup
     @Environment(\.presentationMode) var presentationMode
-    
-    @ObservedObject var quickChallengeViewModel: QuickChallengeViewModel
+    @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
+
     @State var presentDuelOngoingChallenge: Bool = false
     @State var present3or4OngoingChallenge: Bool = false
-    @Binding var quickChallenge: QuickChallenge
+    @State var quickChallenge: QuickChallenge
     @State var isPresentingDeletionAlert: Bool = false
 
+    
     //MARK: - Body
     var body: some View {
-        ZStack {
-            Tokens.Colors.Background.dark.value.edgesIgnoringSafeArea(.all)
-            //MARK: - Back Button
-            VStack (alignment: .leading) {
-                HStack {
+        NavigationView {
+            ZStack {
+                Tokens.Colors.Background.dark.value.edgesIgnoringSafeArea(.all)
+                //MARK: - Back Button
+                VStack (alignment: .leading) {
                     HStack {
-                        Image(systemName: "chevron.left")
-                            .font(.title2)
-                            .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
-                        Text("Back").foregroundColor(Tokens.Colors.Neutral.High.pure.value)
-                    }.onTapGesture {
-                        self.presentationMode.wrappedValue.dismiss()
+                        HStack {
+                            Image(systemName: "chevron.left")
+                                .font(.title2)
+                                .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
+                            Text("Back").foregroundColor(Tokens.Colors.Neutral.High.pure.value)
+                        }.onTapGesture {
+                            self.presentationMode.wrappedValue.dismiss()
+                        }
+                        Spacer()
                     }
                     Spacer()
-                }
-                Spacer()
-            }.padding(Tokens.Spacing.defaultMargin.value)
-            //MARK: - Top Components
-            VStack {
-                VStack(spacing: largeSpacing) {
-                    VStack (alignment: .center, spacing: nanoSpacing) {
-                        HStack(spacing: nanoSpacing) {
-                            Text("⚡️")
+                }.padding(Tokens.Spacing.defaultMargin.value)
+                //MARK: - Top Components
+                VStack {
+                    VStack(spacing: largeSpacing) {
+                        VStack (alignment: .center, spacing: nanoSpacing) {
+                            HStack(spacing: nanoSpacing) {
+                                Text("⚡️")
+                                    .font(titleFont)
+                                    .foregroundColor(color)
+                                
+                                Text(quickChallenge.name)
+                                    .font(titleFont)
+                                    .foregroundColor(color)
+                            }
+                            .padding(.top, largeSpacing)
+                            
+                            Text("Vence quem fizer algo mais vezes \naté bater a pontuação de: ")
+                                .multilineTextAlignment(.center)
+                                .font(descriptionFont)
+                                .foregroundColor(color)
+                            
+                            Text("\(quickChallenge.goal)")
+                                .font(titleFont)
+                                .foregroundColor(color)
+                        }
+                        
+                        //MARK: - Mid Components
+                        VStack(spacing: extraExtraExtraSmallSpacing) {
+                            Text("Participantes")
                                 .font(titleFont)
                                 .foregroundColor(color)
                             
-                            Text(quickChallenge.name)
-                                .font(titleFont)
-                                .foregroundColor(color)
+                            GroupComponent(scoreboard: false, style: [.participantDefault(isSmall: false)], quickChallenge: $quickChallenge)
+                            
                         }
-                        .padding(.top, largeSpacing)
-                        
-                        Text("Vence quem fizer algo mais vezes \naté bater a pontuação de: ")
-                            .multilineTextAlignment(.center)
-                            .font(descriptionFont)
-                            .foregroundColor(color)
-                        
-                        Text("\(quickChallenge.goal)")
-                            .font(titleFont)
-                            .foregroundColor(color)
                     }
+                    .padding()
                     
-                    //MARK: - Mid Components
-                    VStack(spacing: extraExtraExtraSmallSpacing) {
-                        Text("Participantes")
-                            .font(titleFont)
-                            .foregroundColor(color)
-                        
-                        GroupComponent(scoreboard: false, style: [.participantDefault(isSmall: false)], quickChallenge: $quickChallenge)
-                        
-                    }
-                }
-                .padding()
-                
-                Spacer()
-                
-                //MARK: - Bottom Components
-                VStack(spacing: quarkSpacing) {
-                    NavigationLink("", isActive: self.$presentDuelOngoingChallenge) {
-                        DuelScreenView()
-                    }
-                    .hidden()
+                    Spacer()
                     
-                    NavigationLink("", isActive: self.$present3or4OngoingChallenge) {
-                        Ongoing3Or4WithPauseScreenView(quickChallenge: quickChallenge, didTapPauseButton: false)
-                    }
-                    .hidden()
-                    
-                    ButtonComponent(style: .secondary(isEnabled: true),
-                                    text: "Começar desafio!") {
+                    //MARK: - Bottom Components
+                    VStack(spacing: quarkSpacing) {
                         if self.quickChallenge.maxTeams == 2 {
-                            self.presentDuelOngoingChallenge.toggle()
+                            NavigationLink("", isActive: self.$presentDuelOngoingChallenge) {
+                                DuelScreenView()
+                            }
+                            .hidden()
                         }
                         else {
-                            self.present3or4OngoingChallenge.toggle()
+                            NavigationLink("", isActive: self.$present3or4OngoingChallenge) {
+                                Ongoing3Or4WithPauseScreenView(quickChallenge: quickChallenge, didTapPauseButton: false)
+                            }
+                            .hidden()
+                        }
+                        
+                        ButtonComponent(style: .secondary(isEnabled: true),
+                                        text: "Começar desafio!") {
+                            if self.quickChallenge.maxTeams == 2 {
+                                self.presentDuelOngoingChallenge.toggle()
+                            }
+                            else {
+                                self.present3or4OngoingChallenge.toggle()
+                            }
+                        }
+                        
+                        ButtonComponent(style: .black(isEnabled: true),
+                                        text: "Deletar desafio") {
+                            self.isPresentingDeletionAlert.toggle()
                         }
                     }
-                    
-                    ButtonComponent(style: .black(isEnabled: true),
-                                    text: "Deletar desafio") {
-                        self.isPresentingDeletionAlert.toggle()
-                    }
+                    .padding(.bottom, largeSpacing)
                 }
-                .padding(.bottom, largeSpacing)
+                .padding()
+                .alert(isPresented: self.$isPresentingDeletionAlert, content: {
+                    //TODO: Fix alert content
+                    Alert(title: Text("Deletar desafio"), message: Text("Essa ação não poderá ser desfeita"), primaryButton: .cancel(Text("Cancelar"), action: {
+                        self.isPresentingDeletionAlert = false
+                    }), secondaryButton: .destructive(Text("Apagar desafio"), action: {
+                        self.quickChallengeViewModel.deleteChallenge(by: quickChallenge.id)
+                        
+                        if !self.quickChallengeViewModel.challengesList.contains(where: { $0.id == self.quickChallenge.id }) {
+                            self.presentationMode.wrappedValue.dismiss()
+                        }
+                    }))
+                })
             }
-            .padding()
-            .alert(isPresented: self.$isPresentingDeletionAlert, content: {
-                //TODO: Fix alert content
-                Alert(title: Text("Deletar desafio"), message: Text("Essa ação não poderá ser desfeita"), primaryButton: .cancel(Text("Cancelar"), action: {
-                    self.isPresentingDeletionAlert = false
-                }), secondaryButton: .destructive(Text("Apagar desafio"), action: {
-                    self.quickChallengeViewModel.deleteChallenge(by: quickChallenge.id)
-                    
-                    if !self.quickChallengeViewModel.challengesList.contains(where: { $0.id == self.quickChallenge.id }) {
-                        self.presentationMode.wrappedValue.dismiss()
-                    }
-                }))
-            })
+            .accentColor(Color.white)
+            .navigationBarHidden(true)
+            .navigationBarBackButtonHidden(true)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationViewStyle(StackNavigationViewStyle())
         }
-        .accentColor(Color.white)
     }
     
     //MARK: - DS Tokens
@@ -148,6 +158,7 @@ struct ChallengeDetailsView: View {
 //MARK: - Previews
 struct ChallengeDetailsScreenView_Previews: PreviewProvider {
     static var previews: some View {
-        ChallengeDetailsView(quickChallengeViewModel: QuickChallengeViewModel(), quickChallenge: .constant(QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [Team(id: "id", name: "Naty", quickChallengeId: "id", createdAt: "", updatedAt: ""), Team(id: "id2", name: "player2", quickChallengeId: "id", createdAt: "", updatedAt: "")], owner: User(email: "a@naty.pq", name: "naty"))))
+        ChallengeDetailsView(quickChallenge: QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [Team(id: "id", name: "Naty", quickChallengeId: "id", createdAt: "", updatedAt: ""), Team(id: "id2", name: "player2", quickChallengeId: "id", createdAt: "", updatedAt: "")], owner: User(email: "a@naty.pq", name: "naty")))
+            .environmentObject(QuickChallengeViewModel())
     }
 }

--- a/Fiero/Views/Challenges/Quick/Ongoing/DuelScreenView.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/DuelScreenView.swift
@@ -18,7 +18,6 @@ struct DuelScreenView: View {
             if self.didTapPauseButton {
                 PauseScreen(didTapPauseButton: $didTapPauseButton, didFinishChallenge: $didFinishChallenge)
                 if self.didFinishChallenge {
-                    
                     ChallengesListScreenView()
                 }
             }

--- a/Fiero/Views/Challenges/Quick/Ongoing/DuelScreenView.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/DuelScreenView.swift
@@ -18,7 +18,7 @@ struct DuelScreenView: View {
             if self.didTapPauseButton {
                 PauseScreen(didTapPauseButton: $didTapPauseButton, didFinishChallenge: $didFinishChallenge)
                 if self.didFinishChallenge {
-                    ChallengesListScreenView()
+                    HomeView()
                 }
             }
         }

--- a/Fiero/Views/Challenges/Quick/Ongoing/DuelScreenView.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/DuelScreenView.swift
@@ -8,14 +8,19 @@
 import SwiftUI
 
 struct DuelScreenView: View {
-
     @State var didTapPauseButton: Bool = false
+    @State var didFinishChallenge: Bool = false
+    @State var isPresentingAlert: Bool = false
 
     var body: some View {
         ZStack {
             OngoingDuelScreenView(didTapPauseButton: $didTapPauseButton)
             if self.didTapPauseButton {
-                PauseScreen(didTapPauseButton: $didTapPauseButton)
+                PauseScreen(didTapPauseButton: $didTapPauseButton, didFinishChallenge: $didFinishChallenge)
+                if self.didFinishChallenge {
+                    
+                    ChallengesListScreenView()
+                }
             }
         }
     }

--- a/Fiero/Views/Challenges/Quick/Ongoing/Ongoing3_4ScreenView.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/Ongoing3_4ScreenView.swift
@@ -18,7 +18,7 @@ struct Ongoing3Or4WithPauseScreenView: View {
             if self.didTapPauseButton {
                 PauseScreen(didTapPauseButton: $didTapPauseButton, didFinishChallenge: $didFinishChallenge)
                 if self.didFinishChallenge {
-                    ChallengesListScreenView()
+                    HomeView()
                 }
             }
         }

--- a/Fiero/Views/Challenges/Quick/Ongoing/Ongoing3_4ScreenView.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/Ongoing3_4ScreenView.swift
@@ -7,8 +7,27 @@
 
 import SwiftUI
 
+struct Ongoing3Or4WithPauseScreenView: View {
+    @State var quickChallenge: QuickChallenge
+    @State var didTapPauseButton: Bool = false
+    @State var didFinishChallenge: Bool = false
+    
+    var body: some View {
+        ZStack {
+            Ongoing3_4ScreenView(quickChallenge: quickChallenge, didTapPauseButton: $didTapPauseButton)
+            if self.didTapPauseButton {
+                PauseScreen(didTapPauseButton: $didTapPauseButton, didFinishChallenge: $didFinishChallenge)
+                if self.didFinishChallenge {
+                    ChallengesListScreenView()
+                }
+            }
+        }
+    }
+}
+
 struct Ongoing3_4ScreenView: View {
     @State var quickChallenge: QuickChallenge
+    @Binding var didTapPauseButton: Bool
     
     var body: some View {
         ZStack {
@@ -16,7 +35,7 @@ struct Ongoing3_4ScreenView: View {
             VStack {
                 HStack {
                     Button {
-                        print("pause")
+                        self.didTapPauseButton.toggle()
                     } label: {
                         Image(systemName: "pause.circle.fill")
                             .resizable()
@@ -51,7 +70,6 @@ struct Ongoing3_4ScreenView: View {
                 }), quickChallenge: $quickChallenge)
                 .frame(height: UIScreen.main.bounds.height * 0.2)
                 .padding([.horizontal], Tokens.Spacing.defaultMargin.value)
-                //.padding([.horizontal], Tokens.Spacing.xxxs.value)
                 
                 VStack(spacing: Tokens.Spacing.quarck.value) {
                     ForEach($quickChallenge.teams) { team in
@@ -63,9 +81,8 @@ struct Ongoing3_4ScreenView: View {
                     }
                 }
                 
-                ButtonComponent(style: .secondary(isEnabled: true), text: "Finalizar desafio") {
+                ButtonComponent(style: .secondary(isEnabled: true), text: "Ir para a lista de desafios") {
                     //call func from ViewModel to update players scores
-                    
                     //call func from ViewModel to finish the challenge
                 }
                 .padding(.bottom, Tokens.Spacing.md.value)
@@ -80,14 +97,15 @@ struct Ongoing3_4ScreenView: View {
 }
 
 struct Ongoing3_4ScreenView_Previews: PreviewProvider {
+    
     static var previews: some View {
-        Ongoing3_4ScreenView(quickChallenge: QuickChallenge(id: "teste", name: "Truco", invitationCode: "teste", type: "Quantidade", goal: 3, goalMeasure: "unity", finished: false, ownerId: "teste", online: false, alreadyBegin: true, maxTeams: 4, createdAt: "teste", updatedAt: "teste", teams:
+        Ongoing3Or4WithPauseScreenView(quickChallenge: QuickChallenge(id: "teste", name: "Truco", invitationCode: "teste", type: "Quantidade", goal: 3, goalMeasure: "unity", finished: false, ownerId: "teste", online: false, alreadyBegin: true, maxTeams: 4, createdAt: "teste", updatedAt: "teste", teams:
                 [
                     Team(id: "teste1", name: "player1", quickChallengeId: "teste", ownerId: "teste", createdAt: "", updatedAt: "", members: [Member(id: "", score: 22, userId: "", teamId: "", beginDate: "", botPicture: "player1", createdAt: "", updatedAt: "")]),
                     Team(id: "teste2", name: "player2", quickChallengeId: "teste", ownerId: "teste", createdAt: "", updatedAt: "", members: [Member(id: "", score: 12, userId: "", teamId: "", beginDate: "", botPicture: "player2", createdAt: "", updatedAt: "")]),
                     Team(id: "teste3", name: "player3", quickChallengeId: "teste", ownerId: "teste", createdAt: "", updatedAt: "", members: [Member(id: "", score: 43, userId: "", teamId: "", beginDate: "", botPicture: "player3", createdAt: "", updatedAt: "")]),
                     Team(id: "teste4", name: "player4", quickChallengeId: "teste", ownerId: "teste", createdAt: "", updatedAt: "", members: [Member(id: "", score: 200, userId: "", teamId: "", beginDate: "", botPicture: "player4", createdAt: "", updatedAt: "")])
                 ],
-                owner: User(email: "teste", name: "teste")))
+                                                            owner: User(email: "teste", name: "teste")))
     }
 }

--- a/Fiero/Views/Challenges/Quick/Ongoing/Ongoing3_4ScreenView.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/Ongoing3_4ScreenView.swift
@@ -82,6 +82,7 @@ struct Ongoing3_4ScreenView: View {
                 }
                 
                 ButtonComponent(style: .secondary(isEnabled: true), text: "Ir para a lista de desafios") {
+                    RootViewController.popToRootViewController()
                     //call func from ViewModel to update players scores
                     //call func from ViewModel to finish the challenge
                 }

--- a/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct PauseScreen: View {
+    @Environment(\.rootPresentationMode) var rootPresentationMode
+
     @Binding var didTapPauseButton: Bool
     @Binding var didFinishChallenge: Bool
     
@@ -44,6 +46,8 @@ struct PauseScreen: View {
                 }
                 ButtonComponent(style: .secondary(isEnabled: true), text: "Ir para a lista de desafios") {
                     self.didFinishChallenge.toggle()
+                    //self.rootPresentationMode.wrappedValue.popToRootViewController()
+                    RootViewController.dismissSheetFlow()
                     //call func from ViewModel to update players scores
                     
                     //call func from ViewModel to finish the challenge

--- a/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PauseScreen: View {
     @Binding var didTapPauseButton: Bool
+    @Binding var didFinishChallenge: Bool
     
     //MARK: Colors
     var backgroundColor: Color {
@@ -41,7 +42,11 @@ struct PauseScreen: View {
                 ButtonComponent(style: .primary(isEnabled: true), text: "Retornar ao desafio") {
                     self.didTapPauseButton.toggle()
                 }
-                ButtonComponent(style: .secondary(isEnabled: true), text: "Finalizar desafio") {
+                ButtonComponent(style: .secondary(isEnabled: true), text: "Ir para a lista de desafios") {
+                    self.didFinishChallenge.toggle()
+                    //call func from ViewModel to update players scores
+                    
+                    //call func from ViewModel to finish the challenge
                 }
             }
             .padding(.horizontal, spacingDefaultMargin)
@@ -54,6 +59,6 @@ struct PauseScreen: View {
 
 struct PauseScreen_Previews: PreviewProvider {
     static var previews: some View {
-        PauseScreen(didTapPauseButton: .constant(false))
+        PauseScreen(didTapPauseButton: .constant(false), didFinishChallenge: .constant(false))
     }
 }

--- a/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct PauseScreen: View {
-    @Environment(\.rootPresentationMode) var rootPresentationMode
-
     @Binding var didTapPauseButton: Bool
     @Binding var didFinishChallenge: Bool
     
@@ -46,8 +44,7 @@ struct PauseScreen: View {
                 }
                 ButtonComponent(style: .secondary(isEnabled: true), text: "Ir para a lista de desafios") {
                     self.didFinishChallenge.toggle()
-                    //self.rootPresentationMode.wrappedValue.popToRootViewController()
-                    RootViewController.dismissSheetFlow()
+                    RootViewController.popToRootViewController()
                     //call func from ViewModel to update players scores
                     
                     //call func from ViewModel to finish the challenge

--- a/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
+++ b/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 //MARK: QCChallengeCreatedView
 struct QCChallengeCreatedView: View {
     //MARK: - Variables Setup
-    @Environment(\.rootPresentationMode) private var rootPresentationMode
     @Environment(\.presentationMode) var presentationMode
     
     @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
@@ -65,10 +64,7 @@ struct QCChallengeCreatedView: View {
             if self.serverResponse.statusCode == 201 ||
                 self.serverResponse.statusCode == 200 {
                 Button(action: {
-                    //self.rootPresentationMode.wrappedValue.popToRootViewController()
-                    //RootViewController.dismissSheetFlow()
                     RootViewController.popToRootViewController()
-                    //self.presentationMode.wrappedValue.dismiss()
                 }, label: {
                     Text("Ir para lista de desafios")
                         .bold()
@@ -104,7 +100,7 @@ struct QCChallengeCreatedView: View {
                 .padding(.horizontal, Tokens.Spacing.xxxs.value)
                 
                 Button(action: {
-                    self.rootPresentationMode.wrappedValue.popToRootViewController()
+                    RootViewController.popToRootViewController()
                 }, label: {
                     Text("Voltar para o início")
                         .bold()

--- a/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
+++ b/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
@@ -78,7 +78,7 @@ struct QCChallengeCreatedView: View {
                 .hidden()
                 
                 NavigationLink("", isActive: self.$present3Or4Challenge) {
-                    Ongoing3_4ScreenView(quickChallenge: self.quickChallenge, didTapPauseButton: Binding.constant(false))
+                    Ongoing3Or4WithPauseScreenView(quickChallenge: self.quickChallenge, didTapPauseButton: false, didFinishChallenge: false)
                 }
                 .hidden()
                 

--- a/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
+++ b/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct QCChallengeCreatedView: View {
     //MARK: - Variables Setup
     @Environment(\.rootPresentationMode) private var rootPresentationMode
+    @Environment(\.presentationMode) var presentationMode
     
     @EnvironmentObject var quickChallengeViewModel: QuickChallengeViewModel
     @State var didPushToHomeScreen: Bool = false
@@ -64,7 +65,10 @@ struct QCChallengeCreatedView: View {
             if self.serverResponse.statusCode == 201 ||
                 self.serverResponse.statusCode == 200 {
                 Button(action: {
-                    self.rootPresentationMode.wrappedValue.popToRootViewController()
+                    //self.rootPresentationMode.wrappedValue.popToRootViewController()
+                    //RootViewController.dismissSheetFlow()
+                    RootViewController.popToRootViewController()
+                    //self.presentationMode.wrappedValue.dismiss()
                 }, label: {
                     Text("Ir para lista de desafios")
                         .bold()
@@ -129,7 +133,7 @@ struct QCChallengeCreatedView: View {
 
 struct QuickChallengeCreatedView_Previews: PreviewProvider {
     static var previews: some View {
-        QCChallengeCreatedView(quickChallengeViewModel: QuickChallengeViewModel(), serverResponse: .constant(.badRequest), quickChallenge: .constant(QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [], owner: User(email: "", name: ""))), challengeType: .amount, challengeName: "", challengeParticipants: 0, goal: 0)
+        QCChallengeCreatedView(serverResponse: .constant(.badRequest), quickChallenge: .constant(QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [], owner: User(email: "", name: ""))), challengeType: .amount, challengeName: "", challengeParticipants: 0, goal: 0)
             //.previewDevice(PreviewDevice(rawValue: "iPhone SE (3rd generation)"))
             .previewDevice(PreviewDevice(rawValue: "iPhone 8 Plus"))
             .environmentObject(QuickChallengeViewModel())

--- a/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
+++ b/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
@@ -13,9 +13,12 @@ struct QCChallengeCreatedView: View {
     
     @ObservedObject var quickChallengeViewModel: QuickChallengeViewModel
     @State var didPushToHomeScreen: Bool = false
-    @State var didPushToStartChallenge: Bool = false
+    //@State var didPushToStartChallenge: Bool = false
+    @State var presentDuelChallenge: Bool = false
+    @State var present3Or4Challenge: Bool = false
     @State var isPresentingAlert: Bool = false
     @Binding var serverResponse: ServerResponse
+    @Binding var quickChallenge: QuickChallenge
     
     var challengeType: QCType
     var challengeName: String
@@ -58,8 +61,38 @@ struct QCChallengeCreatedView: View {
             Spacer()
             
             //MARK: - Bottom Buttons
-            if self.serverResponse.statusCode != 201 &&
-                self.serverResponse.statusCode != 200 {
+            if self.serverResponse.statusCode == 201 ||
+                self.serverResponse.statusCode == 200 {
+                Button(action: {
+                    self.rootPresentationMode.wrappedValue.popToRootViewController()
+                }, label: {
+                    Text("Ir para lista de desafios")
+                        .bold()
+                        .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
+                })
+                .padding(.bottom, Tokens.Spacing.xxxs.value)
+                
+                NavigationLink("", isActive: self.$presentDuelChallenge) {
+                    DuelScreenView()
+                }
+                .hidden()
+                
+                NavigationLink("", isActive: self.$present3Or4Challenge) {
+                    Ongoing3_4ScreenView(quickChallenge: self.quickChallenge, didTapPauseButton: Binding.constant(false))
+                }
+                .hidden()
+                
+                ButtonComponent(style: .secondary(isEnabled: true), text: "Começar desafio!", action: {
+                    if quickChallenge.maxTeams == 2 {
+                        presentDuelChallenge.toggle()
+                    }
+                    else {
+                        present3Or4Challenge.toggle()
+                    }
+                })
+                .padding(.bottom, Tokens.Spacing.xxxl.value)
+                .padding(.horizontal, Tokens.Spacing.xxxs.value)
+            } else {
                 ButtonComponent(style: .secondary(isEnabled: true), text: "Tentar novamente", action: {
                     self.quickChallengeViewModel.createQuickChallenge(name: self.challengeName, challengeType: self.challengeType, goal: self.goal, goalMeasure: self.goalMeasure, numberOfTeams: self.challengeParticipants, maxTeams: self.challengeParticipants)
                 })
@@ -74,22 +107,6 @@ struct QCChallengeCreatedView: View {
                         .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
                 })
                 .padding(.bottom, Tokens.Spacing.xxxl.value)
-            }
-            else {
-                Button(action: {
-                    self.rootPresentationMode.wrappedValue.popToRootViewController()
-                }, label: {
-                    Text("Ir para lista de desafios")
-                        .bold()
-                        .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
-                })
-                .padding(.bottom, Tokens.Spacing.xxxs.value)
-                
-                ButtonComponent(style: .secondary(isEnabled: true), text: "Começar desafio!", action: {
-                    
-                })
-                .padding(.bottom, Tokens.Spacing.xxxl.value)
-                .padding(.horizontal, Tokens.Spacing.xxxs.value)
             }
         }
         .alert(isPresented: self.$isPresentingAlert, content: {
@@ -114,7 +131,7 @@ struct QCChallengeCreatedView: View {
 
 struct QuickChallengeCreatedView_Previews: PreviewProvider {
     static var previews: some View {
-        QCChallengeCreatedView(quickChallengeViewModel: QuickChallengeViewModel(), serverResponse: .constant(.badRequest), challengeType: .amount, challengeName: "", challengeParticipants: 0, goal: 0)
+        QCChallengeCreatedView(quickChallengeViewModel: QuickChallengeViewModel(), serverResponse: .constant(.badRequest), quickChallenge: .constant(QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [], owner: User(email: "", name: ""))), challengeType: .amount, challengeName: "", challengeParticipants: 0, goal: 0)
             //.previewDevice(PreviewDevice(rawValue: "iPhone SE (3rd generation)"))
             .previewDevice(PreviewDevice(rawValue: "iPhone 8 Plus"))
     }

--- a/Fiero/Views/DesignSystem/Components/Button/ButtonStyles.swift
+++ b/Fiero/Views/DesignSystem/Components/Button/ButtonStyles.swift
@@ -19,7 +19,7 @@ enum ButtonStyles {
         case .secondary(let isEnabled):
             return isEnabled ? Tokens.Colors.Neutral.High.pure.value : Tokens.Colors.Neutral.Low.light.value
         case .black:
-            return isEnabled ? .black : Tokens.Colors.Neutral.Low.light.value
+            return isEnabled ? .clear : Tokens.Colors.Neutral.Low.light.value
         }
     }
     

--- a/Fiero/Views/TabBar.swift
+++ b/Fiero/Views/TabBar.swift
@@ -16,9 +16,8 @@ struct TabBarView: View {
     }
     
     var body: some View {
-        
         TabView {
-            ChallengesListScreenView()
+            HomeView()
             .environmentObject(self.quickChallengeViewModel)
             .tabItem {
                 Label("Desafios", systemImage: "list.triangle")
@@ -29,6 +28,7 @@ struct TabBarView: View {
                 Label("Perfil", systemImage: "person")
             }
         }
+        .environment(\.colorScheme, .dark)
         .accentColor(Tokens.Colors.Brand.Primary.pure.value)
     }
 }


### PR DESCRIPTION
# What was done? ✅
> Describe in a few words what have you done? 
> - Step 1: Implemented pause screen on ongoing screen (3 or 4 participants - `Ongoing3_4ScreenView`)
> - Step 2: Integrate ongoing screens on create challenge screen (`QCChallengeCreatedView`)
> - Step 3: Integrate ongoing screens on details screen (`ChallengeDetailsView`)
> - Step 4: Modified pause screen button text "Finish challenge" to "Go to challenge list"
> - Step 5: Integrate pause screen to challenge list on `Go to challenge list button`
> - Step 6: Modified `QuickChallengeViewModel.swift ` adding a new `@Published var newlyCreatedChallenge`

# Description 📝
## Project Info 📈
> - US **06**
> - Task 
>   - ID: **27**
>   - Title: **Develop Front-end Integration for Ongoing Screens**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
https://user-images.githubusercontent.com/51174686/186000719-28be3beb-9790-4625-8ea7-7fe541cf38e6.mp4

https://user-images.githubusercontent.com/51174686/186000953-0d468f89-6ef0-4577-9171-da013973ab4c.mp4
