### PR TITLE
Correct challenges list padding on iOs14

### DIFF
--- a/Fiero/Views/Challenges/ChallengesListScreenView.swift
+++ b/Fiero/Views/Challenges/ChallengesListScreenView.swift
@@ -87,7 +87,6 @@ struct ChallengesListScreenView: View {
                 .refreshable {
                     self.quickChallengeViewModel.getUserChallenges()
                 }
-                .ignoresSafeArea(.all, edges: .bottom)
                 .listStyle(.plain)
             } else {
                 //TODO: Refreshable list for iOS 14
@@ -96,8 +95,7 @@ struct ChallengesListScreenView: View {
                         CustomTitleImageListRow(title: challenge.name)
                     })
                     .buttonStyle(PlainButtonStyle())
-                }
-                .ignoresSafeArea(.all, edges: .bottom)
+                }.padding(.horizontal, Tokens.Spacing.defaultMargin.value)
                 .listStyle(.plain)
             }
         }


### PR DESCRIPTION
# What was done? ✅
 Describe in a few words what have you done? 
 - Step 1: Correct challenges list padding on iOs14
 - Step 2: Remove .ignoreSafeArea because now we have TabBar

# Description 📝
## Project Info 📈
 - Task 
   - ID: **64**
   - Title: **Challenge List Padding on iOs14**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
<img src="https://user-images.githubusercontent.com/58398373/186666976-2e24cb40-9063-4b4d-8b21-20f0bef7e2e8.png" alt="Screenshot of login screen" width=414 >

