### PR TITLE
Improvement/tk9999 develop failure alerts details screen

### DIFF
--- a/Fiero.xcodeproj/project.pbxproj
+++ b/Fiero.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		1B9092A92878DB7C0039EBB7 /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B9092A82878DB7C0039EBB7 /* UserResponse.swift */; };
 		489B528E28A575A400ADAF49 /* Ongoing3_4ScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489B528D28A575A400ADAF49 /* Ongoing3_4ScreenView.swift */; };
 		48D6EDCA28A2D48D0069FCE9 /* ScoreController3-4Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D6EDC928A2D48D0069FCE9 /* ScoreController3-4Component.swift */; };
+		CC3AB9D828B95BB1006C0507 /* DetailsAlertCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3AB9D728B95BB1006C0507 /* DetailsAlertCases.swift */; };
 		CC4FEDE928A1922900E53C39 /* DuelScoreStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4FEDE828A1922900E53C39 /* DuelScoreStyle.swift */; };
 		CC4FEDED28A1925800E53C39 /* DuelScoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4FEDEC28A1925800E53C39 /* DuelScoreComponent.swift */; };
 		CC91C91328A2F99D00044EA7 /* ElementsStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC91C91228A2F99D00044EA7 /* ElementsStyles.swift */; };
@@ -170,6 +171,7 @@
 		1BC68C55288F32130055135D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		489B528D28A575A400ADAF49 /* Ongoing3_4ScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ongoing3_4ScreenView.swift; sourceTree = "<group>"; };
 		48D6EDC928A2D48D0069FCE9 /* ScoreController3-4Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScoreController3-4Component.swift"; sourceTree = "<group>"; };
+		CC3AB9D728B95BB1006C0507 /* DetailsAlertCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsAlertCases.swift; sourceTree = "<group>"; };
 		CC4FEDE828A1922900E53C39 /* DuelScoreStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuelScoreStyle.swift; sourceTree = "<group>"; };
 		CC4FEDEC28A1925800E53C39 /* DuelScoreComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuelScoreComponent.swift; sourceTree = "<group>"; };
 		CC91C91228A2F99D00044EA7 /* ElementsStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsStyles.swift; sourceTree = "<group>"; };
@@ -622,6 +624,7 @@
 			isa = PBXGroup;
 			children = (
 				CCFA55A828888A7F00740663 /* ChallengeDetailsView.swift */,
+				CC3AB9D728B95BB1006C0507 /* DetailsAlertCases.swift */,
 			);
 			path = Details;
 			sourceTree = "<group>";
@@ -864,6 +867,7 @@
 				CCFA55A628887F2300740663 /* ParticipantStyles.swift in Sources */,
 				DF7DCDB128AEB65000B387BA /* Profile Picture Component.swift in Sources */,
 				F8E7C76F2887B12E0035E2CE /* ChallengeCellStyle.swift in Sources */,
+				CC3AB9D828B95BB1006C0507 /* DetailsAlertCases.swift in Sources */,
 				DF7DCDB528AEC17B00B387BA /* TabBar.swift in Sources */,
 				CCA22155289C5589006AA03F /* ChallengeDetailsView.swift in Sources */,
 				1B4135B928597E8900C7094A /* FieroApp.swift in Sources */,

--- a/Fiero/ViewModel/QuickChallengeViewModel.swift
+++ b/Fiero/ViewModel/QuickChallengeViewModel.swift
@@ -18,9 +18,9 @@ class QuickChallengeViewModel: ObservableObject {
     @Published var newlyCreatedChallenge: QuickChallenge
     @Published var detailsAlertCases: DetailsAlertCases = .deleteChallenge
     
-    private let BASE_URL: String = "localhost"
+    //private let BASE_URL: String = "localhost"
     //private let BASE_URL: String = "10.41.48.196"
-    //    private let BASE_URL: String = "ec2-18-229-132-19.sa-east-1.compute.amazonaws.com"
+    private let BASE_URL: String = "ec2-54-233-77-56.sa-east-1.compute.amazonaws.com"
     private let ENDPOINT_CREATE_CHALLENGE: String = "/quickChallenge/create"
     private let ENDPOINT_GET_CHALLENGES: String = "/quickChallenge/createdByMe"
     private let ENDPOINT_DELETE_CHALLENGES: String = "/quickChallenge"

--- a/Fiero/ViewModel/QuickChallengeViewModel.swift
+++ b/Fiero/ViewModel/QuickChallengeViewModel.swift
@@ -16,6 +16,7 @@ class QuickChallengeViewModel: ObservableObject {
     @Published var showingAlert = false
     @Published var didUpdateChallenges: Bool = false
     @Published var newlyCreatedChallenge: QuickChallenge
+    @Published var detailsAlertCases: DetailsAlertCases = .deleteChallenge
     
     private let BASE_URL: String = "localhost"
     //private let BASE_URL: String = "10.41.48.196"

--- a/Fiero/ViewModel/UserLoginViewModel.swift
+++ b/Fiero/ViewModel/UserLoginViewModel.swift
@@ -15,8 +15,8 @@ class UserLoginViewModel: ObservableObject {
     @Published private(set) var user: User
     @Published private(set) var serverResponse: ServerResponse
 
-    //private let BASE_URL: String = "ec2-18-229-132-19.sa-east-1.compute.amazonaws.com"
-    private let BASE_URL: String = "localhost"
+    private let BASE_URL: String = "ec2-54-233-77-56.sa-east-1.compute.amazonaws.com"
+    //private let BASE_URL: String = "localhost"
     //private let BASE_URL: String = "10.41.48.196"
     private let ENDPOINT: String = "/user/login"
     

--- a/Fiero/ViewModel/UserRegistrationViewModel.swift
+++ b/Fiero/ViewModel/UserRegistrationViewModel.swift
@@ -15,9 +15,9 @@ class UserRegistrationViewModel: ObservableObject {
     @Published private(set) var serverResponse: ServerResponse
     @Published var keyboardShown: Bool = false
         
-    private let BASE_URL: String = "localhost"
+    //private let BASE_URL: String = "localhost"
     //private let BASE_URL: String = "10.41.48.196"
-    //private let BASE_URL: String = "ec2-18-229-132-19.sa-east-1.compute.amazonaws.com"
+    private let BASE_URL: String = "ec2-54-233-77-56.sa-east-1.compute.amazonaws.com"
     private let ENDPOINT: String = "/user/register"
     
     private(set) var client: HTTPClient

--- a/Fiero/Views/Challenges/EmptyChallengesView.swift
+++ b/Fiero/Views/Challenges/EmptyChallengesView.swift
@@ -16,13 +16,14 @@ struct EmptyChallengesView: View {
 
         VStack {
             Spacer()
+            
             GifImage("tonto")
                 .frame(width: 250, height: 320)
+            
             Text("Você não é ruim,\nsó ainda não ganhou")
                 .multilineTextAlignment(.center)
                 .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
                 .font(Tokens.FontStyle.title.font(weigth: .bold, design: .default))
-//                .padding(Tokens.Spacing.xxs.value)
             
             ButtonComponent(style: .primary(isEnabled: true), text: "Criar um desafio!", action: {
                 self.isPresented.toggle()

--- a/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
+++ b/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
@@ -85,23 +85,18 @@ struct ChallengeDetailsView: View {
                                 .sink(receiveCompletion: { completion in
                                     switch completion {
                                     case .finished:
-                                        print("success")
+                                        if self.quickChallenge.maxTeams == 2 {
+                                            self.presentDuelOngoingChallenge.toggle()
+                                        }
+                                        else {
+                                            self.present3or4OngoingChallenge.toggle()
+                                        }
                                     case .failure:
                                         quickChallengeViewModel.detailsAlertCases = .failureStartChallenge
                                         self.isPresentingAlert.toggle()
-                                        
-                                        
-                                        
                                     }
                                 }, receiveValue: { _ in })
                                 .store(in: &subscriptions)
-                            
-                            if self.quickChallenge.maxTeams == 2 {
-                                self.presentDuelOngoingChallenge.toggle()
-                            }
-                            else {
-                                self.present3or4OngoingChallenge.toggle()
-                            }
                         }
                         
                         ButtonComponent(style: .black(isEnabled: true),
@@ -127,7 +122,8 @@ struct ChallengeDetailsView: View {
                                         self.presentationMode.wrappedValue.dismiss()
                                     case .failure(let error):
                                         print(error)
-                                        // TODO: show alert
+                                        self.quickChallengeViewModel.detailsAlertCases = .deleteChallenge
+                                        self.isPresentingAlert.toggle()
                                     }
                                 } receiveValue: { _ in }
                                 .store(in: &subscriptions)

--- a/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
+++ b/Fiero/Views/Challenges/Quick/Details/ChallengeDetailsView.swift
@@ -84,6 +84,17 @@ struct ChallengeDetailsView: View {
                         ButtonComponent(style: .secondary(isEnabled: true),
                                         text: "Começar desafio!") {
                             self.quickChallengeViewModel.beginChallenge(challengeId: self.quickChallenge.id, alreadyBegin: true)
+                                .sink(receiveCompletion: { completion in
+                                    switch completion {
+                                        case .finished:
+                                            print("success")
+                                        case .failure(let error):
+                                            print("deu erro, apresentar alerta")
+                                            //print(error)
+                                            // TODO: show alert
+                                    }
+                                }, receiveValue: { _ in })
+                                .store(in: &subscriptions)
                             
                             if self.quickChallenge.maxTeams == 2 {
                                 self.presentDuelOngoingChallenge.toggle()

--- a/Fiero/Views/Challenges/Quick/Details/DetailsAlertCases.swift
+++ b/Fiero/Views/Challenges/Quick/Details/DetailsAlertCases.swift
@@ -1,0 +1,40 @@
+//
+//  DetailsAlertCases.swift
+//  Fiero
+//
+//  Created by Natália Brocca dos Santos on 26/08/22.
+//
+
+import Foundation
+
+enum DetailsAlertCases {
+    case deleteChallenge
+    case failureStartChallenge
+    
+    var title: String {
+        switch self {
+        case .deleteChallenge:
+            return "Apagar desafio"
+        case .failureStartChallenge:
+            return "Erro de conexão"
+        }
+    }
+    
+    var message: String {
+        switch self {
+        case .deleteChallenge:
+            return "Essa ação não poderá ser desfeita."
+        case .failureStartChallenge:
+            return "Não foi possível iniciar o desafio, tente novamente mais tarde."
+        }
+    }
+    
+    var primaryButtonText: String {
+        switch self {
+        case .deleteChallenge:
+            return "Cancelar"
+        case .failureStartChallenge:
+            return "OK"
+        }
+    }
+}

--- a/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
+++ b/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
@@ -131,7 +131,6 @@ struct QCChallengeCreatedView: View {
 struct QuickChallengeCreatedView_Previews: PreviewProvider {
     static var previews: some View {
         QCChallengeCreatedView(serverResponse: .constant(.badRequest), quickChallenge: .constant(QuickChallenge(id: "", name: "", invitationCode: "", type: "", goal: 0, goalMeasure: "", finished: false, ownerId: "", online: false, alreadyBegin: false, maxTeams: 0, createdAt: "", updatedAt: "", teams: [], owner: User(email: "", name: ""))), challengeType: .amount, challengeName: "", challengeParticipants: 0, goal: 0)
-            //.previewDevice(PreviewDevice(rawValue: "iPhone SE (3rd generation)"))
             .previewDevice(PreviewDevice(rawValue: "iPhone 8 Plus"))
             .environmentObject(QuickChallengeViewModel())
     }

--- a/Fiero/Views/Challenges/Quick/QCNamingView.swift
+++ b/Fiero/Views/Challenges/Quick/QCNamingView.swift
@@ -44,7 +44,6 @@ struct QCNamingView: View {
                     isNavActiveForAmount.toggle()
                 })
                 .disabled(self.isNavActiveForAmount)
-    //            .frame(height: UIScreen.main.bounds.height * 0.4)
                 
                 //MARK: - Bottom Buttons
                 ButtonComponent(style: .secondary(isEnabled: true), text: "Próximo", action: {

--- a/Fiero/Views/Challenges/WIP/Time/TimePickerSelectionView.swift
+++ b/Fiero/Views/Challenges/WIP/Time/TimePickerSelectionView.swift
@@ -22,7 +22,6 @@ struct TimePickerSelectionView: View {
     private(set) var challengeType: QCType
     private(set) var challengeName: String
     private(set) var challengeParticipants: Int
-    //private(set) var challengeParameter: QCHighestParameter
     
     var body: some View {
         VStack {
@@ -60,11 +59,6 @@ struct TimePickerSelectionView: View {
             })
             .padding(.bottom)
             .padding(.horizontal, Tokens.Spacing.xxxs.value)
-            
-            NavigationLink("", isActive: self.$pushNextView) {
-//                QCChallengeCreatedView(primaryColor: self.primaryColor, secondaryColor: self.secondaryColor, challengeType: self.challengeType, challengeName: self.challengeName, challengeParticipants: self.challengeParticipants, goal: self.goal)
-            }
-            .hidden()
         }
         .makeDarkModeFullScreen()
         .navigationBarHidden(true)

--- a/Fiero/Views/Login/RegistrationScreenView.swift
+++ b/Fiero/Views/Login/RegistrationScreenView.swift
@@ -24,7 +24,6 @@ struct RegistrationScreenView: View {
     @State private var isShowingInvalidInputAlert: Bool = false
     @State private var isLoginScreenSheetShowing: Bool = false
     @State private var serverResponse: ServerResponse = .unknown
-    
     @Binding private(set) var pushHomeView: Bool
     
     //MARK: - body
@@ -112,8 +111,9 @@ struct RegistrationScreenView: View {
                     UserDefaults.standard.set(self.email, forKey: "email")
                     self.pushHomeView.toggle()
                 }
-                
-                self.isShowingInvalidInputAlert.toggle()
+                else {
+                    self.isShowingInvalidInputAlert.toggle()
+                }
             })
             .onAppear {
                 UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation") // Forcing the rotation to portrait


### PR DESCRIPTION
# What was done? ✅
> Describe in a few words what have you done? 
> - Step 1: Implemented alert for failure start quick challenge
> - Step 2: Created `DetailsAlertCases` enum for alerts cases of challenge details (delete and server error)

# Description 📝
## Project Info 📈
> - Task 
>   - ID: **9999**
>   - Title: **Develop Failure Alerts Details Screen**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱

https://user-images.githubusercontent.com/51174686/186987918-68ebf727-f57b-4612-b4ba-0150e366541e.mp4

https://user-images.githubusercontent.com/51174686/186988065-b7d77798-f665-4abb-a7e9-5455a166236e.mp4

