### PR TITLE
BugFix: TK 99 Fix Finish Challenge Button Working

### DIFF
--- a/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
+++ b/Fiero/Views/Challenges/Quick/Ongoing/PauseScreen.swift
@@ -14,7 +14,7 @@ struct PauseScreen: View {
     @Binding var didTapPauseButton: Bool
     @Binding var didFinishChallenge: Bool
     @Binding var quickChallenge: QuickChallenge
-    @State var isPresentingWinScreen: Bool = false
+    @State var isShowingAlert: Bool = false
 
     
     //MARK: Colors
@@ -53,10 +53,19 @@ struct PauseScreen: View {
                     self.presentationMode.wrappedValue.dismiss()
                 }
                 ButtonComponent(style: .black(isEnabled: true), text: "Finalizar desafio") {
-                    isPresentingWinScreen = true
-                }.fullScreenCover(isPresented: $isPresentingWinScreen) {
-                    WinScreen()
+                    isShowingAlert.toggle()
                 }
+                .alert(isPresented: self.$isShowingAlert, content: {
+                    Alert(title: Text("Finalizar desafio"),
+                          message: Text("Você tem certeza que deseja finalizar este desafio?"), primaryButton: .destructive(Text("Finalizar desafio"), action: {
+                        quickChallengeViewModel.finishChallenge(challengeId: quickChallenge.id, finished: true)
+                        presentationMode.wrappedValue.dismiss()
+                    }), secondaryButton: .cancel(Text("Cancelar")))
+                })
+//                    isPresentingWinScreen = true
+//                }.fullScreenCover(isPresented: $isPresentingWinScreen) {
+//                    WinScreen()
+//                }
             }
             .padding(.horizontal, spacingDefaultMargin)
             .padding(.bottom, 150)


### PR DESCRIPTION
# What was done? ✅
> Describe in a few words what have you done? 
> - Step 1: Fixed action of finish challenge `ButtonComponent` on `PauseScreen.swift`
>   - The action is changing an alert boolean
>   - The alert have two buttons: 
>      - primaryButton: calls the `Finish Challenge` function from the `Quick Challenge ViewModel` and dismisses the details screen
>      - secondaryButton: cancel

# Description 📝
## Project Info 📈
> - Task 
>   - ID: **99**
>   - Title: **Fix Finish Challenge Button Working**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
https://user-images.githubusercontent.com/51174686/189735097-e062b8a4-5d3c-4ce9-91e3-a08ed4dbb4e1.mp4
