### PR TITLE
BUGFIX/TK10 Fix Create Challenge Screens to support smaller devices

### DIFF
--- a/Fiero/Views/Challenges/Quick/QCCategorySelectionView.swift
+++ b/Fiero/Views/Challenges/Quick/QCCategorySelectionView.swift
@@ -43,10 +43,10 @@ struct QCCategorySelectionView: View {
                 Spacer()
                 
                 Text("pickChallengeType")
-                .multilineTextAlignment(.center)
-                .font(Tokens.FontStyle.largeTitle.font(weigth: .bold, design: .default))
-                .padding(.horizontal, Tokens.Spacing.xs.value)
-                .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
+                    .multilineTextAlignment(.center)
+                    .font(Tokens.FontStyle.largeTitle.font(weigth: .bold, design: .default))
+                    .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
+                    .frame(minHeight: 82)
 
                 HStack(alignment: .center,spacing: cardSpacing) {
                     ForEach(0 ..< items.count) { index in

--- a/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
+++ b/Fiero/Views/Challenges/Quick/QCChallengeCreatedView.swift
@@ -56,6 +56,7 @@ struct QCChallengeCreatedView: View {
                 .font(Tokens.FontStyle.largeTitle.font(weigth: .semibold, design: .default))
                 .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
                 .padding(.top, Tokens.Spacing.sm.value)
+                .padding(.horizontal, Tokens.Spacing.defaultMargin.value)
             
             Spacer()
             

--- a/Fiero/Views/DesignSystem/Components/TextFields/PermanentKeyboard.swift
+++ b/Fiero/Views/DesignSystem/Components/TextFields/PermanentKeyboard.swift
@@ -22,7 +22,7 @@ struct PermanentKeyboard: UIViewRepresentable {
     class Coordinator: NSObject, UITextFieldDelegate {
         
         public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-            return range.location < 18
+            return range.location < 13
         }
         
         //MARK: - Variables Setup
@@ -65,7 +65,7 @@ struct PermanentKeyboard: UIViewRepresentable {
         textField.textColor = UIColor(cgColor: Tokens.Colors.Neutral.High.pure.value.cgColor!)
         textField.layer.backgroundColor = UIColor.clear.cgColor
         
-        let font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        let font = UIFont.preferredFont(forTextStyle: .title1)
         textField.font = font
         
         textField.keyboardType = self.keyboardType

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -105,7 +105,7 @@ We can't get your challenges now, try again";
     "Erro" = "Error";
 
 // MARK: - Quick: ChallengeSelectionView
-    "pickChallengeType" = "Choose a challenge type";
+    "pickChallengeType" = "Choose a \nchallenge type";
     "amountChallengeTypeTitle" =  "Amount \nchallenge";
     "amountChallengeTypeSubtitle" = "Whoever gets the score first wins.";
     "timeChallengeTypeTitle" = "Time \nchallenge";


### PR DESCRIPTION
# What was done? ✅
> Describe in a few words what have you done? 
> - Step 1: Fixed min height frame on `Challenge Type text` in `QCCategorySelectionView.swift`
> - Step 2: Fixed number of characters on `PermanentKeyboard textField`
> - Step 3: Changed font on `PermanentKeyboard  textField` for .title1 (before was .largeTitle)
> - Step4: Inserted `\n` on `pickChallengeType English Localizable`
> - Step 5: Added a horizontal padding on `Successfully created challenge` in `QCChallengeCreatedView.swift`

# Description 📝
## Project Info 📈
> - Task 
>   - ID: **10**
>   - Title: **Fix Create Challenge Screens to support smaller devices**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
![IPhoneSE](https://user-images.githubusercontent.com/51174686/194127620-a8f2205d-57cd-4ca6-9ae2-6d4f5390cf5d.png)
![IPhone8](https://user-images.githubusercontent.com/51174686/194127674-c0eb3303-3282-4c52-9808-6f820d3da3dd.png)
![IPhone14ProMax](https://user-images.githubusercontent.com/51174686/194127701-230923be-7dae-4eaf-bfa4-bfa1d7fa05e6.png)