### PR TITLE
Tk73 login/signup screen support smaller devices

### DIFF
--- a/Fiero.xcodeproj/project.pbxproj
+++ b/Fiero.xcodeproj/project.pbxproj
@@ -114,8 +114,8 @@
 		DFD4FED328B92DD700169C20 /* quantity.gif in Resources */ = {isa = PBXBuildFile; fileRef = DFD4FED228B92DD700169C20 /* quantity.gif */; };
 		DFF31A0828C7D7EC002EFD9D /* OnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF31A0628C7D7EC002EFD9D /* OnboardingCard.swift */; };
 		DFF31A0928C7D7EC002EFD9D /* Onboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF31A0728C7D7EC002EFD9D /* Onboarding.swift */; };
-		F834EEBE28F09D6800D44C49 /* RecoverPasswordEmailStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = F834EEBD28F09D6800D44C49 /* RecoverPasswordEmailStep.swift */; };
-		F834EEC028F09E3400D44C49 /* InputConfirmationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F834EEBF28F09E3400D44C49 /* InputConfirmationCode.swift */; };
+		F834EEBE28F09D6800D44C49 /* RecoverPasswordEmailStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F834EEBD28F09D6800D44C49 /* RecoverPasswordEmailStepView.swift */; };
+		F834EEC028F09E3400D44C49 /* InputConfirmationCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F834EEBF28F09E3400D44C49 /* InputConfirmationCodeView.swift */; };
 		F85EE0182881D30700264114 /* RoundScoreStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85EE0172881D30700264114 /* RoundScoreStyle.swift */; };
 		F85EE01A2881D73C00264114 /* RoundScoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85EE0192881D73C00264114 /* RoundScoreComponent.swift */; };
 		F888EC01287600C300445FED /* AlertStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = F888EC00287600C300445FED /* AlertStyles.swift */; };
@@ -254,8 +254,8 @@
 		DFD4FED228B92DD700169C20 /* quantity.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = quantity.gif; sourceTree = "<group>"; };
 		DFF31A0628C7D7EC002EFD9D /* OnboardingCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCard.swift; sourceTree = "<group>"; };
 		DFF31A0728C7D7EC002EFD9D /* Onboarding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Onboarding.swift; sourceTree = "<group>"; };
-		F834EEBD28F09D6800D44C49 /* RecoverPasswordEmailStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverPasswordEmailStep.swift; sourceTree = "<group>"; };
-		F834EEBF28F09E3400D44C49 /* InputConfirmationCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputConfirmationCode.swift; sourceTree = "<group>"; };
+		F834EEBD28F09D6800D44C49 /* RecoverPasswordEmailStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverPasswordEmailStepView.swift; sourceTree = "<group>"; };
+		F834EEBF28F09E3400D44C49 /* InputConfirmationCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputConfirmationCodeView.swift; sourceTree = "<group>"; };
 		F85EE0172881D30700264114 /* RoundScoreStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundScoreStyle.swift; sourceTree = "<group>"; };
 		F85EE0192881D73C00264114 /* RoundScoreComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundScoreComponent.swift; sourceTree = "<group>"; };
 		F888EC00287600C300445FED /* AlertStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStyles.swift; sourceTree = "<group>"; };
@@ -770,8 +770,8 @@
 		F834EEBC28F09D1B00D44C49 /* Recover Password */ = {
 			isa = PBXGroup;
 			children = (
-				F834EEBD28F09D6800D44C49 /* RecoverPasswordEmailStep.swift */,
-				F834EEBF28F09E3400D44C49 /* InputConfirmationCode.swift */,
+				F834EEBD28F09D6800D44C49 /* RecoverPasswordEmailStepView.swift */,
+				F834EEBF28F09E3400D44C49 /* InputConfirmationCodeView.swift */,
 			);
 			path = "Recover Password";
 			sourceTree = "<group>";
@@ -1017,7 +1017,7 @@
 				1B0A02852885F03100C4A421 /* QCCategorySelectionView.swift in Sources */,
 				1BC4CFD928EF598F0039A230 /* AuthTokenService.swift in Sources */,
 				CCFA55A628887F2300740663 /* ParticipantStyles.swift in Sources */,
-				F834EEBE28F09D6800D44C49 /* RecoverPasswordEmailStep.swift in Sources */,
+				F834EEBE28F09D6800D44C49 /* RecoverPasswordEmailStepView.swift in Sources */,
 				DF7DCDB128AEB65000B387BA /* Profile Picture Component.swift in Sources */,
 				CC3AB9E028C1433E006C0507 /* ScrollingModifier.swift in Sources */,
 				F8E7C76F2887B12E0035E2CE /* ChallengeCellStyle.swift in Sources */,
@@ -1047,7 +1047,7 @@
 				489B528E28A575A400ADAF49 /* Ongoing3_4ScreenView.swift in Sources */,
 				DF94A38E28C2236F003B47B8 /* WinScreen.swift in Sources */,
 				1B90929C2878A5A40039EBB7 /* ButtonStyles.swift in Sources */,
-				F834EEC028F09E3400D44C49 /* InputConfirmationCode.swift in Sources */,
+				F834EEC028F09E3400D44C49 /* InputConfirmationCodeView.swift in Sources */,
 				CCFA559628872D1B00740663 /* QuantityTimeComponent.swift in Sources */,
 				CC91C91328A2F99D00044EA7 /* ElementsStyles.swift in Sources */,
 				1B5B7CE428761F7800B4628F /* TextFieldStyleVariant.swift in Sources */,

--- a/Fiero/Views/Login/AccountLoginView.swift
+++ b/Fiero/Views/Login/AccountLoginView.swift
@@ -75,6 +75,10 @@ struct AccountLoginView: View {
                                              design: .default)
     }
     
+    init() {
+        UINavigationBar.appearance().backgroundColor = UIColor(Tokens.Colors.Background.dark.value)
+        }
+    
     //MARK: body View
     var body: some View {
         ZStack {
@@ -224,6 +228,7 @@ struct AccountLoginView: View {
             }
             .padding(.horizontal, smallSpacing)
             .padding(.bottom, Tokens.Spacing.xxxs.value)
+                
             if userViewModel.isShowingLoading {
                 ZStack {
                     Tokens.Colors.Neutral.Low.pure.value.edgesIgnoringSafeArea(.all).opacity(0.9)

--- a/Fiero/Views/Login/AccountLoginView.swift
+++ b/Fiero/Views/Login/AccountLoginView.swift
@@ -179,7 +179,6 @@ struct AccountLoginView: View {
                             Text("forgotYourPassword")
                                 .font(textFont)
                                 .foregroundColor(color)
-                                .accessibilityLabel("teste")
                         })
                         .padding(.top, nanoSpacing )
                         .padding(.bottom, nanoSpacing + quarck)

--- a/Fiero/Views/Login/AccountLoginView.swift
+++ b/Fiero/Views/Login/AccountLoginView.swift
@@ -116,6 +116,7 @@ struct AccountLoginView: View {
                                           linkedTextHandler: {
                             isShowingTermsOfUseSheet.toggle()
                         })
+                        .padding(.vertical, Tokens.Spacing.nano.value)
                         .sheet(isPresented: $isShowingTermsOfUseSheet) {
                             TermsOfUseSheetView(termsOfUseAccept: $hasAcceptedTermsOfUse)
                         }
@@ -147,6 +148,7 @@ struct AccountLoginView: View {
                             .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
                             .font(Tokens.FontStyle.callout.font(weigth: .bold))
                         }
+                        .padding(.top, smallSpacing)
                     }
                 } else {
                     //MARK: - Login View
@@ -183,7 +185,7 @@ struct AccountLoginView: View {
                         .padding(.bottom, nanoSpacing + quarck)
                         .sheet(isPresented: $isPresentingRecoverPasswordSheet) {
                             NavigationView {
-                                RecoverPasswordEmailStep()
+                                RecoverPasswordEmailStepView()
                                     .navigationBarItems(trailing: Button("Fechar", action: {self.isPresentingRecoverPasswordSheet.toggle()}))
                                     .navigationBarTitle("navigationTitle", displayMode: .inline)
                             }
@@ -222,6 +224,7 @@ struct AccountLoginView: View {
                 }
             }
             .padding(.horizontal, smallSpacing)
+            .padding(.bottom, Tokens.Spacing.xxxs.value)
             if userViewModel.isShowingLoading {
                 ZStack {
                     Tokens.Colors.Neutral.Low.pure.value.edgesIgnoringSafeArea(.all).opacity(0.9)

--- a/Fiero/Views/Login/Recover Password/InputConfirmationCodeView.swift
+++ b/Fiero/Views/Login/Recover Password/InputConfirmationCodeView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct InputConfirmationCode: View {
+struct InputConfirmationCodeView: View {
     @Environment(\.presentationMode) var presentationMode
     
     @EnvironmentObject var userViewModel: UserViewModel
@@ -83,6 +83,6 @@ struct InputConfirmationCode: View {
 
 struct InputConfirmationCode_Previews: PreviewProvider {
     static var previews: some View {
-        InputConfirmationCode()
+        InputConfirmationCodeView()
     }
 }

--- a/Fiero/Views/Login/Recover Password/InputConfirmationCodeView.swift
+++ b/Fiero/Views/Login/Recover Password/InputConfirmationCodeView.swift
@@ -26,62 +26,63 @@ struct InputConfirmationCodeView: View {
     var body: some View {
         ZStack {
             Tokens.Colors.Background.dark.value.ignoresSafeArea()
-            
-            VStack (spacing: Tokens.Spacing.xxxs.value){
-                Spacer()
-                Text("verificationcationCodeTitleLabel")
-                    .font(Tokens.FontStyle.largeTitle.font(weigth: .bold))
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.bottom, Tokens.Spacing.nano.value)
-                
-                CustomTextFieldView(
-                    type: .none,
-                    style: .primary,
-                    placeholder: "verificationCodeTextFieldPlaceholder",
-                    keyboardType: .alphabet,
-                    isSecure: false,
-                    isLowCase: true ,
-                    isWrong: .constant(false),
-                    text: self.$confirmationCode)
-                
-                CustomTextFieldView(
-                    type: .none,
-                    style: .primary,
-                    placeholder: "passwordTextFieldPlaceholder",
-                    keyboardType: .alphabet,
-                    isSecure: false,
-                    isLowCase: true ,
-                    isWrong: .constant(false),
-                    text: self.$confirmationCode)
-                
-                CustomTextFieldView(
-                    type: .none,
-                    style: .primary,
-                    placeholder: "confirmPasswordTextFieldPlaceholder",
-                    keyboardType: .alphabet,
-                    isSecure: false,
-                    isLowCase: true ,
-                    isWrong: .constant(false),
-                    text: self.$confirmationCode)
-                
-                ButtonComponent(
-                    style: .primary(isEnabled: true),
-                    text: "changePasswordButtonLabel",
-                    action: {
-                        //TODO: - verify confirmation code before go to next step
-                        self.isPresentingNewPassword.toggle()
-                    })
-                ButtonComponent(
-                    style: .black(isEnabled: true),
-                    text: "resendEmailVerification",
-                    action: {
-                        //TODO: - verify confirmation code before go to next step
-        
-                    })
-                
-            }.padding(.horizontal,Tokens.Spacing.defaultMargin.value)
+            ScrollView{
+                VStack (spacing: Tokens.Spacing.xxxs.value){
+                    Spacer()
+                    Text("verificationcationCodeTitleLabel")
+                        .font(Tokens.FontStyle.largeTitle.font(weigth: .bold))
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(Tokens.Colors.Neutral.High.pure.value)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.bottom, Tokens.Spacing.nano.value)
+                    
+                    CustomTextFieldView(
+                        type: .none,
+                        style: .primary,
+                        placeholder: "verificationCodeTextFieldPlaceholder",
+                        keyboardType: .alphabet,
+                        isSecure: false,
+                        isLowCase: true ,
+                        isWrong: .constant(false),
+                        text: self.$confirmationCode)
+                    
+                    CustomTextFieldView(
+                        type: .none,
+                        style: .primary,
+                        placeholder: "passwordTextFieldPlaceholder",
+                        keyboardType: .alphabet,
+                        isSecure: false,
+                        isLowCase: true ,
+                        isWrong: .constant(false),
+                        text: self.$confirmationCode)
+                    
+                    CustomTextFieldView(
+                        type: .none,
+                        style: .primary,
+                        placeholder: "confirmPasswordTextFieldPlaceholder",
+                        keyboardType: .alphabet,
+                        isSecure: false,
+                        isLowCase: true ,
+                        isWrong: .constant(false),
+                        text: self.$confirmationCode)
+                    
+                    ButtonComponent(
+                        style: .primary(isEnabled: true),
+                        text: "changePasswordButtonLabel",
+                        action: {
+                            //TODO: - verify confirmation code before go to next step
+                            self.isPresentingNewPassword.toggle()
+                        })
+                    ButtonComponent(
+                        style: .black(isEnabled: true),
+                        text: "resendEmailVerification",
+                        action: {
+                            //TODO: - verify confirmation code before go to next step
+                            
+                        })
+                    
+                }.padding(.horizontal,Tokens.Spacing.defaultMargin.value)
+            }
         }
         .navigationBarHidden(true)
     }

--- a/Fiero/Views/Login/Recover Password/InputConfirmationCodeView.swift
+++ b/Fiero/Views/Login/Recover Password/InputConfirmationCodeView.swift
@@ -11,10 +11,18 @@ struct InputConfirmationCodeView: View {
     @Environment(\.presentationMode) var presentationMode
     
     @EnvironmentObject var userViewModel: UserViewModel
-
+    
     @State private var confirmationCode: String = ""
     @State var isPresentingNewPassword: Bool = false
-
+    
+    
+    var textFont: Font {
+        return Tokens.FontStyle.callout.font()
+    }
+    var color: Color {
+        return Tokens.Colors.Neutral.High.pure.value
+    }
+    
     var body: some View {
         ZStack {
             Tokens.Colors.Background.dark.value.ignoresSafeArea()
@@ -57,24 +65,22 @@ struct InputConfirmationCodeView: View {
                     isLowCase: true ,
                     isWrong: .constant(false),
                     text: self.$confirmationCode)
-                if userViewModel.keyboardShown {
-                    ButtonComponent(
-                        style: .primary(isEnabled: true),
-                        text: "changePasswordButtonLabel",
-                        action: {
-                            //TODO: - verify confirmation code before go to next step
-                            self.isPresentingNewPassword.toggle()
-                        })
-                    .padding(.bottom, Tokens.Spacing.sm.value)
-                } else {
-                    ButtonComponent(
-                        style: .primary(isEnabled: true),
-                        text: "changePasswordButtonLabel",
-                        action: {
-                            //TODO: - verify confirmation code before go to next step
-                            self.isPresentingNewPassword.toggle()
-                        })
-                }
+                
+                ButtonComponent(
+                    style: .primary(isEnabled: true),
+                    text: "changePasswordButtonLabel",
+                    action: {
+                        //TODO: - verify confirmation code before go to next step
+                        self.isPresentingNewPassword.toggle()
+                    })
+                ButtonComponent(
+                    style: .black(isEnabled: true),
+                    text: "resendEmailVerification",
+                    action: {
+                        //TODO: - verify confirmation code before go to next step
+        
+                    })
+                
             }.padding(.horizontal,Tokens.Spacing.defaultMargin.value)
         }
         .navigationBarHidden(true)

--- a/Fiero/Views/Login/Recover Password/RecoverPasswordEmailStepView.swift
+++ b/Fiero/Views/Login/Recover Password/RecoverPasswordEmailStepView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct RecoverPasswordEmailStep: View {
+struct RecoverPasswordEmailStepView: View {
     @Environment(\.presentationMode) var presentationMode
     
 
@@ -45,7 +45,7 @@ struct RecoverPasswordEmailStep: View {
                             self.isPresentingConfirmCodeScreen.toggle()
                         })
                     NavigationLink("", isActive: self.$isPresentingConfirmCodeScreen) {
-                        InputConfirmationCode()
+                        InputConfirmationCodeView()
                     }.hidden()
                     
                 }.padding(.horizontal,Tokens.Spacing.defaultMargin.value)
@@ -56,6 +56,6 @@ struct RecoverPasswordEmailStep: View {
 
 struct RecoverPasswordEmailStep_Previews: PreviewProvider {
     static var previews: some View {
-        RecoverPasswordEmailStep()
+        RecoverPasswordEmailStepView()
     }
 }

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -201,6 +201,7 @@ We can't get your challenges now, try again";
 "passwordTextFieldPlaceholder" = "New Password";
 "confirmPasswordTextFieldPlaceholder" = "Confirm new password";
 "changePasswordButtonLabel" = "Change password";
+"resendEmailVerification"= "Resend validation code";
 
 //MARK: Alerts
 //MARK: Invalid Email

--- a/pt-BR.lproj/Localizable.strings
+++ b/pt-BR.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "passwordTextFieldPlaceholder" = "Nova senha";
 "confirmPasswordTextFieldPlaceholder" = "Confirme a nova senha";
 "changePasswordButtonLabel" = "Mudar senha";
+"resendEmailVerification"= "Reenviar código de validação";
 
 //MARK: Alerts
 //MARK: Invalid Email


### PR DESCRIPTION
# What was done? ✅
> Describe in a few words what have you done? 
> - Step 1: Fix paddings in Login and Sigup Views
> - Step 2: Add resend validation code on recover password screen
> - Step 3: Add new localizable strings
> - Step 4: Add ScrollView on `InputConfirmationCodeView`

# Description 📝
## Project Info 📈
> - Task 
>   - ID: **73**
>   - Title: **Fix Login/Signup Screen to support smaller devices**
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
If applicable, add screenshots from Figma to help detail how this feature should be implemented.

# Login and Sigup Paddings 
<img width="923" alt="Screen Shot 2022-10-10 at 16 16 24" src="https://user-images.githubusercontent.com/69223192/194937413-057da8be-b356-45e6-bd3a-08e0b9853f73.png">

# `InputConfirmationCodeView()`
<img width="927" alt="Screen Shot 2022-10-10 at 16 30 11" src="https://user-images.githubusercontent.com/69223192/194939373-d5e0d91a-cb4d-4434-94c4-9df22811053e.png">

<img width="934" alt="Screen Shot 2022-10-10 at 16 30 48" src="https://user-images.githubusercontent.com/69223192/194939441-e7a18361-f066-47aa-a7a8-72517d29ba91.png">

