### PR TITLE
fix: change textfield to textview on creation flow

### DIFF
--- a/Fiero.xcodeproj/project.pbxproj
+++ b/Fiero.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		62A9849F28D2216700AE77B5 /* tonto2.json in Resources */ = {isa = PBXBuildFile; fileRef = 62A9849E28D2216600AE77B5 /* tonto2.json */; };
 		62B2943A28D4EF5100E69F69 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 62B2943C28D4EF5100E69F69 /* Localizable.strings */; };
 		CC0D240228F4B8B500C51505 /* OngoingWithPause.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0D240128F4B8B500C51505 /* OngoingWithPause.swift */; };
+		CC38BDB42927F60000536E9C /* CreationFlowTextViewComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC38BDB32927F60000536E9C /* CreationFlowTextViewComponent.swift */; };
+		CC38BDB62927F67400536E9C /* CreationFlowTextViewStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC38BDB52927F67400536E9C /* CreationFlowTextViewStyles.swift */; };
 		CC3AB9D828B95BB1006C0507 /* DetailsAlertCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3AB9D728B95BB1006C0507 /* DetailsAlertCases.swift */; };
 		CC3AB9DA28BE8EE0006C0507 /* LoginAlertCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3AB9D928BE8EE0006C0507 /* LoginAlertCases.swift */; };
 		CC3AB9E028C1433E006C0507 /* ScrollingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3AB9DF28C1433E006C0507 /* ScrollingModifier.swift */; };
@@ -253,6 +255,8 @@
 		62B2943B28D4EF5100E69F69 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		62B2943D28D4EF5300E69F69 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CC0D240128F4B8B500C51505 /* OngoingWithPause.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OngoingWithPause.swift; sourceTree = "<group>"; };
+		CC38BDB32927F60000536E9C /* CreationFlowTextViewComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationFlowTextViewComponent.swift; sourceTree = "<group>"; };
+		CC38BDB52927F67400536E9C /* CreationFlowTextViewStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationFlowTextViewStyles.swift; sourceTree = "<group>"; };
 		CC3AB9D728B95BB1006C0507 /* DetailsAlertCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailsAlertCases.swift; sourceTree = "<group>"; };
 		CC3AB9D928BE8EE0006C0507 /* LoginAlertCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginAlertCases.swift; sourceTree = "<group>"; };
 		CC3AB9DF28C1433E006C0507 /* ScrollingModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingModifier.swift; sourceTree = "<group>"; };
@@ -583,6 +587,7 @@
 		1B8FB39B286F6E8700B9F868 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				CC38BDB22927F5BD00536E9C /* TextViews */,
 				1BF3DA762925571E00BAED81 /* Online */,
 				F8B889962925599E00870A34 /* ScoreList */,
 				DF588A3229105EDE00F10E02 /* InviteCode */,
@@ -696,6 +701,15 @@
 				48D6EDC928A2D48D0069FCE9 /* ScoreController3-4Component.swift */,
 			);
 			path = "ScoreController3-4";
+			sourceTree = "<group>";
+		};
+		CC38BDB22927F5BD00536E9C /* TextViews */ = {
+			isa = PBXGroup;
+			children = (
+				CC38BDB32927F60000536E9C /* CreationFlowTextViewComponent.swift */,
+				CC38BDB52927F67400536E9C /* CreationFlowTextViewStyles.swift */,
+			);
+			path = TextViews;
 			sourceTree = "<group>";
 		};
 		CC4FEDE628A191D100E53C39 /* ScoreControllers */ = {
@@ -1141,6 +1155,7 @@
 				CCFA559828872D2E00740663 /* QuantityTimeStyles.swift in Sources */,
 				DF49516928B902650046A2CD /* GIfImage.swift in Sources */,
 				1B8CD3412887F50B00D2F703 /* QuickChallengeViewModel.swift in Sources */,
+				CC38BDB62927F67400536E9C /* CreationFlowTextViewStyles.swift in Sources */,
 				DF06F8D829114C7C00A170C2 /* ScanViewController.swift in Sources */,
 				1B0A02A92887CACF00C4A421 /* CustomMultiWheelPicker.swift in Sources */,
 				F8E7C7712887B4CD0035E2CE /* ChallengeCellComponent.swift in Sources */,
@@ -1174,6 +1189,7 @@
 				DF7DCDB528AEC17B00B387BA /* TabBar.swift in Sources */,
 				CCA22155289C5589006AA03F /* ChallengeDetailsView.swift in Sources */,
 				1B4135B928597E8900C7094A /* FieroApp.swift in Sources */,
+				CC38BDB42927F60000536E9C /* CreationFlowTextViewComponent.swift in Sources */,
 				1B8CD3432887F8CF00D2F703 /* QuickChallenge.swift in Sources */,
 				CCE03FEF29032FE80038737A /* InviteChallengerView.swift in Sources */,
 				1B8CD34728887ADE00D2F703 /* QCTypeEnum.swift in Sources */,

--- a/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
+++ b/Fiero/Views/Challenges/Quick/Amount/QCAmountWinRulesView.swift
@@ -72,7 +72,7 @@ struct QCAmountWinRulesView: View {
                 
                 Spacer()
                 
-                PermanentKeyboard(text: self.$goal, keyboardType: .numberPad)
+                CreationFlowTextViewComponent(text: self.$goal, style: .points)
                 
                 Spacer()
                 

--- a/Fiero/Views/Challenges/Quick/QCNamingView.swift
+++ b/Fiero/Views/Challenges/Quick/QCNamingView.swift
@@ -37,10 +37,12 @@ struct QCNamingView: View {
                     .padding(.bottom, Tokens.Spacing.quarck.value)
 
                 //MARK: Keyboard
-                PermanentKeyboard(text: self.$challengeName, keyboardType: .default, onCommit: {
+                
+                CreationFlowTextViewComponent(text: self.$challengeName, style: .name) {
                     isNavActiveForAmount.toggle()
-                })
+                }
                 .disabled(self.isNavActiveForAmount)
+                .padding(.top, Tokens.Spacing.xs.value)
                 
                 //MARK: - Bottom Buttons
                 ButtonComponent(style: .secondary(isEnabled: true), text: "Próximo", action: {

--- a/Fiero/Views/DesignSystem/Components/TextViews/CreationFlowTextViewComponent.swift
+++ b/Fiero/Views/DesignSystem/Components/TextViews/CreationFlowTextViewComponent.swift
@@ -59,10 +59,8 @@ struct CreationFlowTextViewComponent: UIViewRepresentable {
     }
     
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView(frame: CGRect(x: 0,
-                                                y: 0,
-                                                width: UIScreen.main.bounds.width - 50,
-                                                height: UIScreen.main.bounds.height/4))
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        
         textView.font = style.textFont
         textView.textColor = UIColor(cgColor: style.textColor)
         textView.layer.backgroundColor = style.backgroundColor

--- a/Fiero/Views/DesignSystem/Components/TextViews/CreationFlowTextViewComponent.swift
+++ b/Fiero/Views/DesignSystem/Components/TextViews/CreationFlowTextViewComponent.swift
@@ -1,0 +1,94 @@
+//
+//  CreationFlowTextViewComponent.swift
+//  Fiero
+//
+//  Created by Natália Brocca dos Santos on 18/11/22.
+//
+import Foundation
+import UIKit
+import SwiftUI
+
+struct CreationFlowTextViewComponent: UIViewRepresentable {
+    @Binding var text: String
+    
+    @State var style: CreationFlowTextViewStyles
+    
+    var onCommit: () -> Void = {}
+    
+    typealias UIViewType = UITextView
+    
+    class Coordinator: NSObject, UITextViewDelegate {
+        var style: CreationFlowTextViewStyles
+        var parent: CreationFlowTextViewComponent
+        var didBecomeFirstResponder: Bool = false
+        
+        init(parent: CreationFlowTextViewComponent, style: CreationFlowTextViewStyles) {
+            self.parent = parent
+            self.style = style
+        }
+        
+        public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+            if style == .name {
+                return range.location < 50
+            }
+            else {
+                return range.location < 18
+            }
+        }
+        
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            DispatchQueue.main.async {
+                self.parent.text = textView.text ?? "didn't work"
+            }
+        }
+        
+        func textViewShouldReturn(_ textView: UITextView) -> Bool {
+            DispatchQueue.main.async {
+                self.parent.text = textView.text ?? "Error on \(#function)"
+            }
+            self.parent.didCommit()
+            textView.isEditable = false
+            textView.resignFirstResponder()
+            
+            return true
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self, style: style)
+    }
+    
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView(frame: CGRect(x: 0,
+                                                y: 0,
+                                                width: UIScreen.main.bounds.width - 50,
+                                                height: UIScreen.main.bounds.height/4))
+        textView.font = style.textFont
+        textView.textColor = UIColor(cgColor: style.textColor)
+        textView.layer.backgroundColor = style.backgroundColor
+        textView.keyboardType = style.keyboardType
+        textView.returnKeyType = style.returnKeyType
+        textView.delegate = context.coordinator
+        
+        return textView
+    }
+    
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.text = text
+        
+        if !uiView.isFirstResponder && !context.coordinator.didBecomeFirstResponder {
+            DispatchQueue.main.async {
+                uiView.becomeFirstResponder()
+            }
+            context.coordinator.didBecomeFirstResponder = true
+        }
+        uiView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        uiView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        uiView.adjustsFontForContentSizeCategory = true
+        uiView.textAlignment = NSTextAlignment.center
+    }
+    
+    func didCommit() {
+        onCommit()
+    }
+}

--- a/Fiero/Views/DesignSystem/Components/TextViews/CreationFlowTextViewStyles.swift
+++ b/Fiero/Views/DesignSystem/Components/TextViews/CreationFlowTextViewStyles.swift
@@ -1,0 +1,40 @@
+//
+//  CreationFlowTextViewStyles.swift
+//  Fiero
+//
+//  Created by Natália Brocca dos Santos on 18/11/22.
+//
+
+import UIKit
+
+enum CreationFlowTextViewStyles {
+    case name
+    case points
+    
+    var textColor: CGColor {
+        return Tokens.Colors.Neutral.High.pure.value.cgColor!
+    }
+    
+    var backgroundColor: CGColor {
+        return UIColor.clear.cgColor
+    }
+    
+    var textFont: UIFont {
+        return .preferredFont(forTextStyle: .largeTitle)
+    }
+    
+    var keyboardType: UIKeyboardType {
+        switch self {
+        case .name:
+            return .alphabet
+        case .points:
+            return .numberPad
+        }
+    }
+    
+    var returnKeyType: UIReturnKeyType {
+        return .default
+    }
+    
+    
+}


### PR DESCRIPTION
# What was done? ✅
> Describe in a few words what have you done? 
> - Step 1: Created a new component and style for textView
> - Step 2: Changed component call (PermanentKeyboard -> CreationFlowTextViewComponent) on `QCNamingView.swift` and `QCAmountWinRulesView.swift`
  
# Evidence 🕵️‍♀️
## **Screenshots/Videos/Figma** 📱
> Challenge name:
https://user-images.githubusercontent.com/51174686/202782475-b7277872-0884-4ff1-875f-a53df6b99f6f.mp4
> Challenge points:
https://user-images.githubusercontent.com/51174686/202782667-1a5b7a7a-c43b-433f-b67d-098f72f5b0a3.mp4


LIST:
<img width="300" src="https://user-images.githubusercontent.com/51174686/202782939-1b62986b-17c4-4589-9129-2c3f7470d50c.png">
DETAILS:
<img width="300" src="https://user-images.githubusercontent.com/51174686/202783057-5862fbde-c8a1-4db6-bf5d-1e0a5da5ef62.png">